### PR TITLE
Feature/cessation plan

### DIFF
--- a/src/routes/cessation-plan/cessation-plan.repository.ts
+++ b/src/routes/cessation-plan/cessation-plan.repository.ts
@@ -18,6 +18,21 @@ export interface CessationPlanFilters {
 export class CessationPlanRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async create(data: CreateCessationPlanType & { user_id: string }) {
+    return this.prisma.cessationPlan.create({
+      data: {
+        user_id: data.user_id,
+        template_id: data.template_id,
+        reason: data.reason,
+        start_date: data.start_date,
+        target_date: data.target_date,
+        is_custom: data.is_custom,
+        status: 'PLANNING',
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
   async findAll(params: PaginationParamsType, filters?: CessationPlanFilters) {
     const { page, limit, search, orderBy, sortOrder } = params;
     const skip = (page - 1) * limit;
@@ -69,21 +84,6 @@ export class CessationPlanRepository {
       },
       include: this.getDefaultIncludes(),
       orderBy: { created_at: 'desc' },
-    });
-  }
-
-  async create(data: CreateCessationPlanType & { user_id: string }) {
-    return this.prisma.cessationPlan.create({
-      data: {
-        user_id: data.user_id,
-        template_id: data.template_id,
-        reason: data.reason,
-        start_date: data.start_date,
-        target_date: data.target_date,
-        is_custom: data.is_custom,
-        status: 'PLANNING',
-      },
-      include: this.getDefaultIncludes(),
     });
   }
 

--- a/src/routes/cessation-plan/cessation-plan.resolver.ts
+++ b/src/routes/cessation-plan/cessation-plan.resolver.ts
@@ -26,7 +26,7 @@ export class CessationPlanResolver {
     @Args('input') input: CreateCessationPlanInput,
     @User() user: UserType,
   ): Promise<CessationPlan> {
-    return this.cessationPlanService.create(input, user.role, user.id);
+    return this.cessationPlanService.create(input, user.id);
   }
 
   @Query(() => PaginatedCessationPlansResponse)

--- a/src/routes/cessation-plan/cessation-plan.service.ts
+++ b/src/routes/cessation-plan/cessation-plan.service.ts
@@ -26,7 +26,7 @@ export class CessationPlanService {
     private readonly planStageRepository: PlanStageRepository,
   ) {}
 
-  async create(data: CreateCessationPlanType, userRole: string, requestUserId: string) {
+  async create(data: CreateCessationPlanType, requestUserId: string) {
     await this.validateCreateRules(data, requestUserId)
 
     try {
@@ -38,7 +38,7 @@ export class CessationPlanService {
       const plan = await this.cessationPlanRepository.create(planData)
       this.logger.log(`Cessation plan created: ${plan.id} for user: ${plan.user_id}`)
 
-      if (plan.template_id && (data.is_custom === undefined || data.is_custom === false)) {
+      if (plan.template_id) {
         try {
           await this.planStageRepository.createStagesFromTemplate(plan.id, plan.template_id)
           this.logger.log(`Stages created from template ${plan.template_id} for plan ${plan.id}`)

--- a/src/routes/plan-stage/plan-stage.repository.ts
+++ b/src/routes/plan-stage/plan-stage.repository.ts
@@ -18,6 +18,23 @@ export interface PlanStageFilters {
 export class PlanStageRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async create(data: CreatePlanStageType) {
+    return this.prisma.planStage.create({
+      data: {
+        plan_id: data.plan_id,
+        template_stage_id: data.template_stage_id,
+        stage_order: data.stage_order,
+        title: data.title,
+        start_date: data.start_date,
+        end_date: data.end_date,
+        description: data.description,
+        actions: data.actions,
+        status: 'PENDING',
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
   async findAll(params: PaginationParamsType, filters?: PlanStageFilters) {
     const { page, limit, search, orderBy, sortOrder } = params;
     const skip = (page - 1) * limit;
@@ -75,23 +92,6 @@ export class PlanStageRepository {
       where: {
         plan_id: planId,
         stage_order: stageOrder,
-      },
-      include: this.getDefaultIncludes(),
-    });
-  }
-
-  async create(data: CreatePlanStageType) {
-    return this.prisma.planStage.create({
-      data: {
-        plan_id: data.plan_id,
-        template_stage_id: data.template_stage_id,
-        stage_order: data.stage_order,
-        title: data.title,
-        start_date: data.start_date,
-        end_date: data.end_date,
-        description: data.description,
-        actions: data.actions,
-        status: 'PENDING',
       },
       include: this.getDefaultIncludes(),
     });


### PR DESCRIPTION
This pull request refactors the `create` methods in the `CessationPlanRepository` and `PlanStageRepository` classes to improve maintainability and simplifies the logic for creating cessation plans and associated stages. It also removes unnecessary parameters in service and resolver methods.

### Refactoring of `create` methods:

* [`src/routes/cessation-plan/cessation-plan.repository.ts`](diffhunk://#diff-6d81bf6184053c47fd87aa5aa27214578213174ea0a721b8357b4110310236d4R21-R35): The `create` method in `CessationPlanRepository` was moved to a different position in the file, with no functional changes. This reorganization improves code readability. [[1]](diffhunk://#diff-6d81bf6184053c47fd87aa5aa27214578213174ea0a721b8357b4110310236d4R21-R35) [[2]](diffhunk://#diff-6d81bf6184053c47fd87aa5aa27214578213174ea0a721b8357b4110310236d4L75-L89)
* [`src/routes/plan-stage/plan-stage.repository.ts`](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R21-R37): Similarly, the `create` method in `PlanStageRepository` was moved and remains functionally the same. [[1]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R21-R37) [[2]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6L83-L99)

### Simplification of service logic:

* [`src/routes/cessation-plan/cessation-plan.service.ts`](diffhunk://#diff-8479545bf990931ba6c68d1cb059ac750166ff0052d4dd0efccaae2531d1762cL29-R29): Removed the `userRole` parameter from the `create` method in `CessationPlanService`, as it was unused. Additionally, simplified the condition for creating stages from templates by removing redundant checks on the `is_custom` field. [[1]](diffhunk://#diff-8479545bf990931ba6c68d1cb059ac750166ff0052d4dd0efccaae2531d1762cL29-R29) [[2]](diffhunk://#diff-8479545bf990931ba6c68d1cb059ac750166ff0052d4dd0efccaae2531d1762cL41-R41)

### Resolver method update:

* [`src/routes/cessation-plan/cessation-plan.resolver.ts`](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL29-R29): Updated the `createCessationPlan` resolver method to remove the `userRole` parameter when calling the `create` method in `CessationPlanService`, aligning it with the updated service method signature.