### PR TITLE
feat(plan-stage): add delete functionality

### DIFF
--- a/prisma/migrations/20250610062328_add_is_deleted_to_plan_stage/migration.sql
+++ b/prisma/migrations/20250610062328_add_is_deleted_to_plan_stage/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "plan_stage" ADD COLUMN     "is_deleted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,7 @@ model PlanStage {
   description       String?
   actions           String?
   status            PlanStageStatus    @default(PENDING)
+  is_deleted        Boolean            @default(false)
   created_at        DateTime           @default(now())
   updated_at        DateTime           @updatedAt
   plan              CessationPlan      @relation(fields: [plan_id], references: [id], onDelete: Cascade)

--- a/src/routes/plan-stage/entities/plan-stage.entity.ts
+++ b/src/routes/plan-stage/entities/plan-stage.entity.ts
@@ -35,6 +35,9 @@ export class PlanStage implements PlanStageType {
   @Field(() => PlanStageStatus)
   status: PlanStageStatus;
 
+  @Field(() => Boolean)
+  is_deleted: boolean;
+
   @Field(() => Date)
   created_at: Date;
 

--- a/src/routes/plan-stage/plan-stage.resolver.ts
+++ b/src/routes/plan-stage/plan-stage.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common';
 import { PlanStageService } from './plan-stage.service';
 import { PlanStage } from './entities/plan-stage.entity';
@@ -96,5 +96,14 @@ export class PlanStageResolver {
       user.role,
       user.id,
     );
+  }
+
+  @Mutation(() => PlanStage)
+  @UseGuards(JwtAuthGuard)
+  async removePlanStage(
+    @Args('id', { type: () => ID }) id: string,
+    @User() user: UserType,
+  ): Promise<PlanStage> {
+    return this.planStageService.remove(id, user.role, user.id);
   }
 }


### PR DESCRIPTION
This pull request introduces a soft delete mechanism for `PlanStage` entities and enhances the handling of plan stages with new methods and validations. It includes database schema updates, API changes, and additional business logic to support these features.

### Soft Delete Implementation:
* Added an `is_deleted` column to the `plan_stage` table with a default value of `false`, and updated the Prisma schema to reflect this change (`migration.sql`, `schema.prisma`). [[1]](diffhunk://#diff-3f5f70fd8dbb5a60ad6297673854566a50f977807174df8cf06ac3631bfb1505R1-R2) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR118)
* Updated repository methods to exclude soft-deleted records by default and added a new `remove` method for soft deletion (`plan-stage.repository.ts`). [[1]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R34-R69) [[2]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6L66-R100) [[3]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R215-R224)

### API Enhancements:
* Added a new GraphQL mutation `removePlanStage` to soft delete a `PlanStage` entity (`plan-stage.resolver.ts`).
* Updated service methods to validate access and handle soft-deleted records appropriately (`plan-stage.service.ts`). [[1]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L49-R106) [[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L154-R175)

### Business Logic Improvements:
* Introduced validation to restrict modifications on non-customizable plans, ensuring stages cannot be manually altered for such plans (`plan-stage.service.ts`).
* Enhanced the `enrichWithComputedFields` method to improve date calculations and overdue status handling (`plan-stage.service.ts`).

### Refactoring and Cleanup:
* Consolidated access validation logic into a new `validateAccessAndGetPlan` method, replacing repetitive permission checks (`plan-stage.service.ts`). [[1]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L93-R122) [[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R194-R238)
* Removed redundant methods and streamlined repository and service classes (`plan-stage.repository.ts`, `plan-stage.service.ts`). [[1]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R123-L107) [[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L110-R146)

These changes improve the flexibility and maintainability of the `PlanStage` module while introducing a robust mechanism for handling soft-deleted records.