### PR TITLE
feat(cessation-plan-template): implement filtering functionality

### DIFF
--- a/src/routes/cessation-plan-template/cessation-plan-template.resolver.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.resolver.ts
@@ -12,6 +12,7 @@ import { PaginationParamsInput } from '../../shared/models/dto/request/paginatio
 import { PaginatedCessationPlanTemplatesResponse } from './dto/response/paginated-cessation-plan-templates.response'
 import { CreateCessationPlanTemplateInput } from './dto/request/create-cessation-plan-template.input'
 import { UpdateCessationPlanTemplateInput } from './dto/request/update-cessation-plan-template.input'
+import { CessationPlanTemplateFiltersInput } from './dto/request/cessation-plan-template-filters.input'
 
 @Resolver(() => CessationPlanTemplate)
 export class CessationPlanTemplateResolver {
@@ -25,9 +26,12 @@ export class CessationPlanTemplateResolver {
     return this.cessationPlanTemplateService.create(input, user)
   }
 
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(JwtAuthGuard)
   @Query(() => PaginatedCessationPlanTemplatesResponse)
-  async cessationPlanTemplates(@Args('params', { nullable: true }) params?: PaginationParamsInput) {
+  async cessationPlanTemplates(
+    @Args('params', { nullable: true }) params?: PaginationParamsInput,
+    @Args('filters', { nullable: true, type: () => CessationPlanTemplateFiltersInput }) filters?: CessationPlanTemplateFiltersInput,
+  ) {
     return this.cessationPlanTemplateService.findAll(
       params || {
         page: 1,
@@ -35,10 +39,11 @@ export class CessationPlanTemplateResolver {
         orderBy: 'created_at',
         sortOrder: 'desc',
       },
+      filters,
     )
   }
 
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(JwtAuthGuard)
   @Query(() => CessationPlanTemplate)
   async cessationPlanTemplate(@Args('id') id: string) {
     return this.cessationPlanTemplateService.findOne(id)
@@ -47,7 +52,7 @@ export class CessationPlanTemplateResolver {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleName.Coach)
   @Mutation(() => CessationPlanTemplate)
-  async updateCessationPlanTemplate(@Args('input') input: UpdateCessationPlanTemplateInput, @User() user: UserType) {
+  async updateCessationPlanTemplate(@Args('input') input: UpdateCessationPlanTemplateInput) {
     const { id, ...updateData } = input
     return this.cessationPlanTemplateService.update(id, updateData)
   }

--- a/src/routes/cessation-plan-template/cessation-plan-template.service.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.service.ts
@@ -5,6 +5,7 @@ import { UpdateCessationPlanTemplateType } from './schema/update-cessation-plan-
 import { PaginationParamsType } from '../../shared/models/pagination.model'
 import { RoleName } from '../../shared/constants/role.constant'
 import { UserType } from 'src/shared/models/share-user.model'
+import { CessationPlanTemplateFiltersInput } from './dto/request/cessation-plan-template-filters.input'
 
 @Injectable()
 export class CessationPlanTemplateService {
@@ -33,10 +34,7 @@ export class CessationPlanTemplateService {
 
   async findAll(
     params: PaginationParamsType,
-    filters?: {
-      difficulty_level?: string
-      is_active?: boolean
-    },
+    filters?: CessationPlanTemplateFiltersInput,
   ) {
     return this.cessationPlanTemplateRepository.findAll(params, filters)
   }

--- a/src/routes/cessation-plan-template/dto/request/cessation-plan-template-filters.input.ts
+++ b/src/routes/cessation-plan-template/dto/request/cessation-plan-template-filters.input.ts
@@ -1,0 +1,16 @@
+import { Field, ID, InputType } from '@nestjs/graphql'
+import { DifficultyLevel } from '@prisma/client'
+import { IsEnum, IsOptional, IsUUID } from 'class-validator'
+
+@InputType()
+export class CessationPlanTemplateFiltersInput {
+  @Field(() => ID, { nullable: true, description: 'Filter by coach ID' })
+  @IsOptional()
+  @IsUUID()
+  coachId?: string;
+
+  @Field(() => String, { nullable: true, description: 'Filter by difficulty level (EASY, MEDIUM, HARD)' })
+  @IsOptional()
+  @IsEnum(DifficultyLevel)
+  difficultyLevel?: DifficultyLevel;
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance the filtering and management of cessation plan templates, primarily by adding a new filtering mechanism, modifying existing methods, and updating related resolver and service logic. The most notable changes include the introduction of a new `CessationPlanTemplateFiltersInput` class, updates to the `findAll` method to support advanced filtering, and adjustments to the GraphQL resolver to accommodate these changes.

### Enhancements to filtering functionality:

* **Added `CessationPlanTemplateFiltersInput` class**: Introduced a new input type for filtering cessation plan templates by `coachId` and `difficultyLevel`, with validation rules for UUID and enum values. (`src/routes/cessation-plan-template/dto/request/cessation-plan-template-filters.input.ts`)
* **Updated `findAll` method**: Modified the `findAll` method in the `CessationPlanTemplateRepository` and `CessationPlanTemplateService` to use the new `CessationPlanTemplateFiltersInput` for filtering templates. (`src/routes/cessation-plan-template/cessation-plan-template.repository.ts`) [[1]](diffhunk://#diff-9a386c771b3e7f115e0ca6c5428e97d3f8bb85d68337c263667da2a8ababfde2R7-R57) [[2]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL36-R37)

### Changes to GraphQL resolver:

* **Enhanced `cessationPlanTemplates` query**: Updated the `cessationPlanTemplates` query in the resolver to accept the new `filters` argument, enabling advanced filtering capabilities. (`src/routes/cessation-plan-template/cessation-plan-template.resolver.ts`)
* **Removed `RolesGuard` from certain queries and mutations**: Simplified access control by removing the `RolesGuard` decorator from several resolver methods. (`src/routes/cessation-plan-template/cessation-plan-template.resolver.ts`) [[1]](diffhunk://#diff-938bde0a903a9ba75e174c213dae48cda50b7e9d74e43760effbb8a5a364a82dL28-R46) [[2]](diffhunk://#diff-938bde0a903a9ba75e174c213dae48cda50b7e9d74e43760effbb8a5a364a82dL50-R55)

### Code restructuring and cleanup:

* **Reordered and reintroduced methods**: Moved the `create` and `delete` methods in the `CessationPlanTemplateRepository` for better organization and reintroduced the `delete` method after a temporary removal. (`src/routes/cessation-plan-template/cessation-plan-template.repository.ts`) [[1]](diffhunk://#diff-9a386c771b3e7f115e0ca6c5428e97d3f8bb85d68337c263667da2a8ababfde2L123-L150) [[2]](diffhunk://#diff-9a386c771b3e7f115e0ca6c5428e97d3f8bb85d68337c263667da2a8ababfde2R200-R206)
* **Added active stage filtering**: Included a condition to filter only active stages when retrieving cessation plan templates. (`src/routes/cessation-plan-template/cessation-plan-template.repository.ts`)