### PR TITLE
Feature/cessation plan

### DIFF
--- a/prisma/migrations/20250610090749_add_is_deleted_to_progress_record/migration.sql
+++ b/prisma/migrations/20250610090749_add_is_deleted_to_progress_record/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "progress_record" ADD COLUMN     "is_deleted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,6 +132,7 @@ model ProgressRecord {
   health_score      Int?
   notes             String?
   record_date       DateTime
+  is_deleted        Boolean       @default(false)
   created_at        DateTime      @default(now())
   updated_at        DateTime      @updatedAt
   plan              CessationPlan @relation(fields: [plan_id], references: [id], onDelete: Cascade)

--- a/src/routes/cessation-plan/cessation-plan.repository.ts
+++ b/src/routes/cessation-plan/cessation-plan.repository.ts
@@ -194,6 +194,7 @@ export class CessationPlanRepository {
         },
       },
       stages: {
+        where: {is_deleted: false},
         orderBy: { stage_order: Prisma.SortOrder.asc },
         include: {
           template_stage: {


### PR DESCRIPTION
This pull request introduces a new `is_deleted` column to the `progress_record` table and updates the related schema and repository logic to support soft deletion. The most important changes include modifying the database schema, updating the Prisma model, and filtering out soft-deleted records in repository queries.

### Database schema updates:
* [`prisma/migrations/20250610090749_add_is_deleted_to_progress_record/migration.sql`](diffhunk://#diff-ea165f9175766e42e6b70f72be63775eea5863d34452370f0e78325af2824c91R1-R2): Added a new `is_deleted` column to the `progress_record` table with a default value of `false`. This enables soft deletion functionality.

### Prisma model updates:
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR135): Updated the `ProgressRecord` model to include the `is_deleted` field with a default value of `false`.

### Repository logic updates:
* [`src/routes/cessation-plan/cessation-plan.repository.ts`](diffhunk://#diff-6d81bf6184053c47fd87aa5aa27214578213174ea0a721b8357b4110310236d4R197): Modified the query for fetching `stages` to exclude records where `is_deleted` is `true`.