### PR TITLE
prisma(database): add badge and social features with related models

### DIFF
--- a/prisma/migrations/20250612152215_add_badge_and_social_features/migration.sql
+++ b/prisma/migrations/20250612152215_add_badge_and_social_features/migration.sql
@@ -1,0 +1,103 @@
+-- CreateEnum
+CREATE TYPE "BadgeType" AS ENUM ('MILESTONE', 'ACHIEVEMENT', 'STREAK', 'COMMUNITY', 'SPECIAL');
+
+-- CreateTable
+CREATE TABLE "badge" (
+    "id" TEXT NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "description" TEXT,
+    "icon_url" TEXT,
+    "badge_type" "BadgeType" NOT NULL,
+    "requirements" JSONB,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "badge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_badge" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "badge_id" TEXT NOT NULL,
+    "awarded_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_badge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shared_post" (
+    "id" TEXT NOT NULL,
+    "user_badge_id" TEXT NOT NULL,
+    "caption" TEXT,
+    "likes_count" INTEGER NOT NULL DEFAULT 0,
+    "comments_count" INTEGER NOT NULL DEFAULT 0,
+    "is_deleted" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "shared_post_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "post_like" (
+    "id" TEXT NOT NULL,
+    "shared_post_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "is_deleted" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "post_like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "post_comment" (
+    "id" TEXT NOT NULL,
+    "shared_post_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "parent_comment_id" TEXT,
+    "content" TEXT NOT NULL,
+    "is_deleted" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "post_comment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_badge_user_id_badge_id_key" ON "user_badge"("user_id", "badge_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shared_post_user_badge_id_key" ON "shared_post"("user_badge_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "post_like_shared_post_id_user_id_key" ON "post_like"("shared_post_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "user_badge" ADD CONSTRAINT "user_badge_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_badge" ADD CONSTRAINT "user_badge_badge_id_fkey" FOREIGN KEY ("badge_id") REFERENCES "badge"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shared_post" ADD CONSTRAINT "shared_post_user_badge_id_fkey" FOREIGN KEY ("user_badge_id") REFERENCES "user_badge"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "post_like" ADD CONSTRAINT "post_like_shared_post_id_fkey" FOREIGN KEY ("shared_post_id") REFERENCES "shared_post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "post_like" ADD CONSTRAINT "post_like_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "post_comment" ADD CONSTRAINT "post_comment_shared_post_id_fkey" FOREIGN KEY ("shared_post_id") REFERENCES "shared_post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "post_comment" ADD CONSTRAINT "post_comment_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "post_comment" ADD CONSTRAINT "post_comment_parent_comment_id_fkey" FOREIGN KEY ("parent_comment_id") REFERENCES "post_comment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,9 @@ model User {
   cessation_plans        CessationPlan[]
   feedbacks              Feedback[]
   Subscription           Subscription[]
+  user_badges            UserBadge[]
+  post_likes             PostLike[]
+  post_comments          PostComment[]
 }
 
 model Blog {
@@ -155,6 +158,92 @@ model Feedback {
 
   @@unique([user_id, template_id])
   @@map("feedback")
+}
+
+model Badge {
+  id           String      @id @default(uuid())
+  name         String      @db.VarChar(100)
+  description  String?
+  icon_url     String?
+  badge_type   BadgeType
+  requirements Json?
+  is_active    Boolean     @default(true)
+  sort_order   Int         @default(0)
+  created_at   DateTime    @default(now())
+  updated_at   DateTime    @updatedAt
+  user_badges  UserBadge[]
+
+  @@map("badge")
+}
+
+model UserBadge {
+  id          String      @id @default(uuid())
+  user_id     String
+  badge_id    String
+  awarded_at  DateTime    @default(now())
+  is_active   Boolean     @default(true)
+  created_at  DateTime    @default(now())
+  updated_at  DateTime    @updatedAt
+  user        User        @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  badge       Badge       @relation(fields: [badge_id], references: [id], onDelete: Cascade)
+  shared_post SharedPost?
+
+  @@unique([user_id, badge_id])
+  @@map("user_badge")
+}
+
+model SharedPost {
+  id             String        @id @default(uuid())
+  user_badge_id  String        @unique
+  caption        String?
+  likes_count    Int           @default(0)
+  comments_count Int           @default(0)
+  is_deleted     Boolean       @default(false)
+  created_at     DateTime      @default(now())
+  updated_at     DateTime      @updatedAt
+  user_badge     UserBadge     @relation(fields: [user_badge_id], references: [id], onDelete: Cascade)
+  likes          PostLike[]
+  comments       PostComment[]
+
+  @@map("shared_post")
+}
+
+model PostLike {
+  id             String     @id @default(uuid())
+  shared_post_id String
+  user_id        String
+  is_deleted     Boolean    @default(false)
+  created_at     DateTime   @default(now())
+  shared_post    SharedPost @relation(fields: [shared_post_id], references: [id], onDelete: Cascade)
+  user           User       @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([shared_post_id, user_id])
+  @@map("post_like")
+}
+
+model PostComment {
+  id                String        @id @default(uuid())
+  shared_post_id    String
+  user_id           String
+  parent_comment_id String?
+  content           String
+  is_deleted        Boolean       @default(false)
+  created_at        DateTime      @default(now())
+  updated_at        DateTime      @updatedAt
+  shared_post       SharedPost    @relation(fields: [shared_post_id], references: [id], onDelete: Cascade)
+  user              User          @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  parent_comment    PostComment?  @relation("CommentReplies", fields: [parent_comment_id], references: [id])
+  replies           PostComment[] @relation("CommentReplies")
+
+  @@map("post_comment")
+}
+
+enum BadgeType {
+  MILESTONE
+  ACHIEVEMENT
+  STREAK
+  COMMUNITY
+  SPECIAL
 }
 
 enum CessationPlanStatus {


### PR DESCRIPTION
This pull request introduces a new feature set to support badges and social interactions in the application. The changes include database schema updates, new models, and relationships to enable badges, user badge tracking, shared posts, likes, and comments. Below is a summary of the most important changes:

### Database Schema Changes:
* Added a new enum `BadgeType` to categorize badges (e.g., MILESTONE, ACHIEVEMENT). (`prisma/migrations/20250612152215_add_badge_and_social_features/migration.sql`, [prisma/migrations/20250612152215_add_badge_and_social_features/migration.sqlR1-R103](diffhunk://#diff-8ed4887c86ae641603134651748306897cc5e6332febb882d8937f7a38ce3155R1-R103))
* Created new tables: `badge`, `user_badge`, `shared_post`, `post_like`, and `post_comment` with appropriate fields, constraints, and foreign key relationships. (`prisma/migrations/20250612152215_add_badge_and_social_features/migration.sql`, [prisma/migrations/20250612152215_add_badge_and_social_features/migration.sqlR1-R103](diffhunk://#diff-8ed4887c86ae641603134651748306897cc5e6332febb882d8937f7a38ce3155R1-R103))

### Prisma Schema Updates:
* Added new models: `Badge`, `UserBadge`, `SharedPost`, `PostLike`, and `PostComment` with fields, relationships, and mappings to the database schema. (`prisma/schema.prisma`, [prisma/schema.prismaR163-R248](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR163-R248))
* Introduced the `BadgeType` enum in the Prisma schema to align with the database schema. (`prisma/schema.prisma`, [prisma/schema.prismaR163-R248](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR163-R248))
* Updated the `User` model to include relationships for `user_badges`, `post_likes`, and `post_comments`. (`prisma/schema.prisma`, [prisma/schema.prismaR29-R31](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR29-R31))