### PR TITLE
Feature/user badge

### DIFF
--- a/prisma/migrations/20250613080142_fix_badge_structure/migration.sql
+++ b/prisma/migrations/20250613080142_fix_badge_structure/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `badge_type` on the `badge` table. All the data in the column will be lost.
+  - Added the required column `badge_type_id` to the `badge` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "badge" DROP COLUMN "badge_type",
+ADD COLUMN     "badge_type_id" TEXT NOT NULL;
+
+-- DropEnum
+DROP TYPE "BadgeType";
+
+-- CreateTable
+CREATE TABLE "badge_type" (
+    "id" TEXT NOT NULL,
+    "name" VARCHAR(50) NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "badge_type_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "badge_type_name_key" ON "badge_type"("name");
+
+-- AddForeignKey
+ALTER TABLE "badge" ADD CONSTRAINT "badge_badge_type_id_fkey" FOREIGN KEY ("badge_type_id") REFERENCES "badge_type"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,18 +161,30 @@ model Feedback {
   @@map("feedback")
 }
 
+model BadgeType {
+  id         String   @id @default(uuid())
+  name       String   @unique @db.VarChar(50)
+  is_active  Boolean  @default(true)
+  badges     Badge[]
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  @@map("badge_type")
+}
+
 model Badge {
-  id           String      @id @default(uuid())
-  name         String      @db.VarChar(100)
-  description  String?
-  icon_url     String?
-  badge_type   BadgeType
-  requirements Json?
-  is_active    Boolean     @default(true)
-  sort_order   Int         @default(0)
-  created_at   DateTime    @default(now())
-  updated_at   DateTime    @updatedAt
-  user_badges  UserBadge[]
+  id            String      @id @default(uuid())
+  name          String      @db.VarChar(100)
+  description   String?
+  icon_url      String?
+  requirements  Json?
+  is_active     Boolean     @default(true)
+  sort_order    Int         @default(0)
+  created_at    DateTime    @default(now())
+  updated_at    DateTime    @updatedAt
+  badge_type    BadgeType   @relation(fields: [badge_type_id], references: [id])
+  user_badges   UserBadge[]
+  badge_type_id String
 
   @@map("badge")
 }
@@ -237,14 +249,6 @@ model PostComment {
   replies           PostComment[] @relation("CommentReplies")
 
   @@map("post_comment")
-}
-
-enum BadgeType {
-  MILESTONE
-  ACHIEVEMENT
-  STREAK
-  COMMUNITY
-  SPECIAL
 }
 
 enum CessationPlanStatus {


### PR DESCRIPTION
This pull request refactors the `badge` structure in the database schema and introduces a new `BadgeType` model to improve data organization and relationships. The changes include removing the `BadgeType` enum, creating a dedicated `BadgeType` table, and updating the `Badge` model to reference the new table.

### Database schema changes:

* **Migration file updates**:
  - Dropped the `badge_type` column from the `badge` table and added a new `badge_type_id` column to establish a foreign key relationship with the new `badge_type` table.
  - Created a new `badge_type` table with columns for `id`, `name`, `is_active`, `created_at`, and `updated_at`, along with a unique index on the `name` column.
  - Dropped the `BadgeType` enum and replaced it with the new `badge_type` table.

### Prisma schema changes:

* **New `BadgeType` model**:
  - Added the `BadgeType` model to represent badge types as a database table with fields for `id`, `name`, `is_active`, `created_at`, and `updated_at`.
  
* **Updated `Badge` model**:
  - Removed the `BadgeType` enum reference and replaced it with a relation to the new `BadgeType` model using the `badge_type_id` field.
  - Added the `badge_type_id` field to support the foreign key relationship.

* **Removed `BadgeType` enum**:
  - Deleted the `BadgeType` enum from the schema as it is now replaced by the `BadgeType` model and table.