### PR TITLE
fix(feedback): fix feedback creation after deleting feedback

### DIFF
--- a/src/routes/feedback/feedback.repository.ts
+++ b/src/routes/feedback/feedback.repository.ts
@@ -44,6 +44,18 @@ export class FeedbackRepository {
     });
   }
 
+  async findAnyByUserAndTemplate(userId: string, templateId: string): Promise<Feedback | null> {
+    return this.prisma.feedback.findUnique({
+      where: {
+        user_id_template_id: {
+          user_id: userId,
+          template_id: templateId,
+        },
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
   async findAll(params: PaginationParamsType, filters?: FeedbackFiltersInput) {
     const { page, limit, orderBy, sortOrder } = params;
     const skip = (page - 1) * limit;
@@ -115,10 +127,18 @@ export class FeedbackRepository {
     });
   }
 
+  async updateById(id: string, data: Partial<Prisma.FeedbackUpdateInput>): Promise<Feedback | null> {
+    return this.prisma.feedback.update({
+      where: { id },
+      data,
+      include: this.getDefaultIncludes(),
+    });
+  }
+
   async remove(id: string): Promise<Feedback | null> {
     return this.prisma.feedback.update({
       where: { id, is_deleted: false },
-      data: { is_deleted: true },
+      data: { is_deleted: true, updated_at: new Date() },
       include: this.getDefaultIncludes(),
     });
   }


### PR DESCRIPTION
This pull request introduces changes to enhance feedback handling in the `FeedbackRepository` and `FeedbackService`. The updates include adding new repository methods for finding and updating feedback records, overhauling feedback creation logic to handle reactivation of deleted feedback, and removing redundant checks for existing feedback.

### Updates to `FeedbackRepository`:

* Added `findAnyByUserAndTemplate` method to retrieve feedback records by user and template, including deleted ones, enabling more flexible queries.
* Added `updateById` method to update feedback records by ID, supporting partial updates and including default relationships.
* Enhanced `remove` method to update the `updated_at` timestamp when marking feedback as deleted.

### Updates to `FeedbackService`:

* Refactored feedback creation logic to support reactivation of deleted feedback. If a deleted feedback record exists, it is updated and reactivated instead of creating a new record.
* Removed the `checkExistingFeedback` method, consolidating its functionality into the new feedback creation logic.