### PR TITLE
feat(shared-post): implement shared post functionality

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { BadgeModule } from './routes/badge/badge.module';
 import { BadgeTypeModule } from './routes/badge-type/badge-type.module';
 import { UserBadgeModule } from './routes/user-badge/user-badge.module';
 import { BadgeAwardModule } from './routes/badge-award/badge-award.module';
+import { SharedPostModule } from './routes/shared-post/shared-post.module';
 
 @Module({
   imports: [
@@ -70,6 +71,7 @@ import { BadgeAwardModule } from './routes/badge-award/badge-award.module';
     BadgeTypeModule,
     UserBadgeModule,
     BadgeAwardModule,
+    SharedPostModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/routes/shared-post/dto/request/create-shared-post.input.ts
+++ b/src/routes/shared-post/dto/request/create-shared-post.input.ts
@@ -1,0 +1,16 @@
+import { InputType, Field, ID } from '@nestjs/graphql'
+import { IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator'
+
+@InputType()
+export class CreateSharedPostInput {
+  @Field(() => ID, { description: 'ID of the UserBadge to be shared' })
+  @IsNotEmpty()
+  @IsUUID()
+  user_badge_id: string;
+
+  @Field(() => String, { nullable: true, description: 'Optional caption for the post' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  caption?: string;
+}

--- a/src/routes/shared-post/dto/request/shared-post-filter.input.ts
+++ b/src/routes/shared-post/dto/request/shared-post-filter.input.ts
@@ -1,0 +1,20 @@
+import { Field, ID, InputType } from '@nestjs/graphql'
+import { IsOptional, IsUUID } from 'class-validator'
+
+@InputType()
+export class SharedPostFiltersInput {
+  @Field(() => ID, { nullable: true, description: 'Filter by user ID (owner of the UserBadge)' })
+  @IsOptional()
+  @IsUUID()
+  user_id?: string;
+
+  @Field(() => ID, { nullable: true, description: 'Filter by badge ID' })
+  @IsOptional()
+  @IsUUID()
+  badge_id?: string;
+
+  @Field(() => ID, { nullable: true })
+  @IsOptional()
+  @IsUUID()
+  badge_type_id?: string;
+}

--- a/src/routes/shared-post/dto/request/update-shared-post.input.ts
+++ b/src/routes/shared-post/dto/request/update-shared-post.input.ts
@@ -1,0 +1,11 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsOptional, IsString, MaxLength } from 'class-validator'
+
+@InputType()
+export class UpdateSharedPostInput {
+  @Field(() => String, { nullable: true, description: 'New caption for the post' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  caption?: string;
+}

--- a/src/routes/shared-post/dto/response/paginated-shared-post.response.ts
+++ b/src/routes/shared-post/dto/response/paginated-shared-post.response.ts
@@ -1,0 +1,20 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+import { SharedPost } from '../../entities/shared-post.entity'
+
+@ObjectType()
+export class PaginatedSharedPostsResponse {
+  @Field(() => [SharedPost])
+  data: SharedPost[];
+
+  @Field(() => Int)
+  total: number;
+
+  @Field(() => Int)
+  page: number;
+
+  @Field(() => Int)
+  limit: number;
+
+  @Field(() => Boolean)
+  hasNext: boolean;
+}

--- a/src/routes/shared-post/entities/shared-post.entity.ts
+++ b/src/routes/shared-post/entities/shared-post.entity.ts
@@ -1,0 +1,32 @@
+import { ObjectType, Field, Int, ID } from '@nestjs/graphql'
+import { UserBadge } from '../../user-badge/entities/user-badge.entity'
+
+@ObjectType()
+export class SharedPost {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => String, { description: 'ID of the UserBadge being shared' })
+  user_badge_id: string;
+
+  @Field(() => UserBadge, { description: 'The UserBadge being shared' })
+  user_badge: UserBadge;
+
+  @Field(() => String, { nullable: true, description: 'Caption for the shared post' })
+  caption?: string;
+
+  @Field(() => Int, { defaultValue: 0, description: 'Number of likes on this post' })
+  likes_count: number;
+
+  @Field(() => Int, { defaultValue: 0, description: 'Number of comments on this post' })
+  comments_count: number;
+
+  @Field(() => Boolean, { description: 'Indicates if the post is soft-deleted' })
+  is_deleted: boolean;
+
+  @Field(() => Date)
+  created_at: Date;
+
+  @Field(() => Date)
+  updated_at: Date;
+}

--- a/src/routes/shared-post/shared-post.module.ts
+++ b/src/routes/shared-post/shared-post.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { SharedPostService } from './shared-post.service';
+import { SharedPostResolver } from './shared-post.resolver';
+import { GuardModule } from '../../shared/guards/guard.module'
+import { SupabaseModule } from '../../shared/modules/supabase.module'
+import { UserBadgeModule } from '../user-badge/user-badge.module'
+import { SharedPostRepository } from './shared-post.repository'
+
+@Module({
+  imports: [
+    GuardModule,
+    SupabaseModule,
+    UserBadgeModule,
+  ],
+  providers: [SharedPostResolver, SharedPostService, SharedPostRepository],
+  exports: [SharedPostService, SharedPostRepository],
+})
+export class SharedPostModule {}

--- a/src/routes/shared-post/shared-post.repository.ts
+++ b/src/routes/shared-post/shared-post.repository.ts
@@ -1,0 +1,165 @@
+import { Prisma } from '@prisma/client'
+import { UpdateSharedPostInput } from './dto/request/update-shared-post.input'
+import { PaginationParamsType } from '../../shared/models/pagination.model'
+import { SharedPostFiltersInput } from './dto/request/shared-post-filter.input'
+import { CreateSharedPostInput } from './dto/request/create-shared-post.input'
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from '../../shared/services/prisma.service'
+
+@Injectable()
+export class SharedPostRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: CreateSharedPostInput, userId: string) {
+    return this.prisma.sharedPost.create({
+      data: {
+        user_badge_id: data.user_badge_id,
+        caption: data.caption,
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findOne(id: string) {
+    return this.prisma.sharedPost.findUnique({
+      where: { id, is_deleted: false },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findOneWithAnyStatus(id: string) { // Dùng để update/delete
+    return this.prisma.sharedPost.findUnique({
+      where: { id },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findByUserBadgeId(userBadgeId: string) {
+    return this.prisma.sharedPost.findUnique({
+      where: { user_badge_id: userBadgeId, is_deleted: false },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findActiveByUserBadgeId(userBadgeId: string) {
+    return this.prisma.sharedPost.findUnique({
+      where: { user_badge_id: userBadgeId, is_deleted: false },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findAnyByUserBadgeId(userBadgeId: string) {
+    return this.prisma.sharedPost.findUnique({
+      where: { user_badge_id: userBadgeId },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findAll(params: PaginationParamsType, filters?: SharedPostFiltersInput) {
+    const { page, limit, orderBy = 'created_at', sortOrder = 'desc' } = params;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.SharedPostWhereInput = {
+      is_deleted: false,
+    };
+
+    if (filters?.user_id) {
+      where.user_badge = {
+        user_id: filters.user_id,
+        is_active: true,
+      };
+    }
+
+    if (filters?.badge_id) {
+      if (!where.user_badge) where.user_badge = { is_active: true };
+      (where.user_badge as Prisma.UserBadgeWhereInput).badge_id = filters.badge_id;
+      (where.user_badge as Prisma.UserBadgeWhereInput).badge = { is_active: true }; // Chỉ lấy badge active
+    }
+
+    if (filters?.badge_type_id) {
+      if (!where.user_badge) where.user_badge = { is_active: true };
+      if (!(where.user_badge as Prisma.UserBadgeWhereInput).badge) {
+         (where.user_badge as Prisma.UserBadgeWhereInput).badge = { is_active: true };
+      }
+      ((where.user_badge as Prisma.UserBadgeWhereInput).badge as Prisma.BadgeWhereInput).badge_type_id = filters.badge_type_id;
+    }
+
+    const [data, total] = await this.prisma.$transaction([
+      this.prisma.sharedPost.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { [orderBy]: sortOrder },
+        include: this.getDefaultIncludes(),
+      }),
+      this.prisma.sharedPost.count({ where }),
+    ]);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      hasNext: total > page * limit,
+    };
+  }
+
+  async update(id: string, data: UpdateSharedPostInput) {
+    return this.prisma.sharedPost.update({
+      where: { id, is_deleted: false },
+      data: {
+        caption: data.caption,
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async updateAndReactivate(id: string, caption?: string | null) {
+    return this.prisma.sharedPost.update({
+      where: { id },
+      data: {
+        caption: caption,
+        is_deleted: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async delete(id: string) {
+    return this.prisma.sharedPost.update({
+      where: { id, is_deleted: false },
+      data: {
+        is_deleted: true,
+        updated_at: new Date(),
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  private getDefaultIncludes(): Prisma.SharedPostInclude {
+    return {
+      user_badge: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              user_name: true,
+              avatar_url: true,
+              role: true,
+            },
+          },
+          badge: {
+            include: {
+              badge_type: true,
+            },
+          },
+        },
+      },
+      // likes: true,
+      // comments: true,
+    };
+  }
+}

--- a/src/routes/shared-post/shared-post.resolver.spec.ts
+++ b/src/routes/shared-post/shared-post.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SharedPostResolver } from './shared-post.resolver';
+import { SharedPostService } from './shared-post.service';
+
+describe('SharedPostResolver', () => {
+  let resolver: SharedPostResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SharedPostResolver, SharedPostService],
+    }).compile();
+
+    resolver = module.get<SharedPostResolver>(SharedPostResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/src/routes/shared-post/shared-post.resolver.ts
+++ b/src/routes/shared-post/shared-post.resolver.ts
@@ -1,0 +1,58 @@
+import { Resolver, Query, Mutation, Args, ID } from '@nestjs/graphql'
+import { SharedPostService } from './shared-post.service';
+import { SharedPost } from './entities/shared-post.entity';
+import { CreateSharedPostInput } from './dto/request/create-shared-post.input';
+import { UpdateSharedPostInput } from './dto/request/update-shared-post.input'
+import { UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
+import { User } from '../../shared/decorators/current-user.decorator'
+import { UserType } from '../../shared/models/share-user.model'
+import { PaginatedSharedPostsResponse } from './dto/response/paginated-shared-post.response'
+import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
+import { SharedPostFiltersInput } from './dto/request/shared-post-filter.input'
+
+@Resolver(() => SharedPost)
+@UseGuards(JwtAuthGuard)
+export class SharedPostResolver {
+  constructor(private readonly sharedPostService: SharedPostService) {}
+
+  @Mutation(() => SharedPost, { description: 'Create a new shared post from a UserBadge' })
+  async createSharedPost(
+    @Args('input') input: CreateSharedPostInput,
+    @User() currentUser: UserType,
+  ): Promise<SharedPost> {
+    return this.sharedPostService.create(input, currentUser);
+  }
+
+  @Query(() => SharedPost, { name: 'sharedPost', description: 'Get a single shared post by ID' })
+  async getSharedPost(@Args('id', { type: () => ID }) id: string): Promise<SharedPost> {
+    return this.sharedPostService.findOne(id);
+  }
+
+  @Query(() => PaginatedSharedPostsResponse, { name: 'sharedPosts', description: 'Get a list of shared posts (feed)' })
+  async getSharedPosts(
+    @Args('params', { type: () => PaginationParamsInput, nullable: true, defaultValue: { page: 1, limit: 10, orderBy: 'created_at', sortOrder: 'desc' } })
+    params: PaginationParamsInput,
+    @Args('filters', { type: () => SharedPostFiltersInput, nullable: true })
+    filters?: SharedPostFiltersInput,
+  ): Promise<PaginatedSharedPostsResponse> {
+    return this.sharedPostService.findAll(params, filters);
+  }
+
+  @Mutation(() => SharedPost, { description: 'Update the caption of a shared post' })
+  async updateSharedPost(
+    @Args('id', { type: () => ID }) id: string,
+    @Args('input') input: UpdateSharedPostInput,
+    @User() currentUser: UserType,
+  ): Promise<SharedPost> {
+    return this.sharedPostService.update(id, input, currentUser);
+  }
+
+  @Mutation(() => SharedPost, { description: 'Soft delete a shared post' })
+  async removeSharedPost(
+    @Args('id', { type: () => ID }) id: string,
+    @User() currentUser: UserType,
+  ): Promise<SharedPost> {
+    return this.sharedPostService.remove(id, currentUser);
+  }
+}

--- a/src/routes/shared-post/shared-post.service.spec.ts
+++ b/src/routes/shared-post/shared-post.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SharedPostService } from './shared-post.service';
+
+describe('SharedPostService', () => {
+  let service: SharedPostService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SharedPostService],
+    }).compile();
+
+    service = module.get<SharedPostService>(SharedPostService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/routes/shared-post/shared-post.service.ts
+++ b/src/routes/shared-post/shared-post.service.ts
@@ -1,0 +1,188 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common'
+import { CreateSharedPostInput } from './dto/request/create-shared-post.input';
+import { UpdateSharedPostInput } from './dto/request/update-shared-post.input'
+import { SharedPostRepository } from './shared-post.repository'
+import { UserBadgeRepository } from '../user-badge/user-badge.repository'
+import { SharedPost } from './entities/shared-post.entity'
+import { UserType } from 'src/shared/models/share-user.model';
+import { PaginationParamsType } from '../../shared/models/pagination.model'
+import { SharedPostFiltersInput } from './dto/request/shared-post-filter.input'
+import { PaginatedSharedPostsResponse } from './dto/response/paginated-shared-post.response'
+import { RoleName } from '../../shared/constants/role.constant'
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class SharedPostService {
+  private readonly logger = new Logger(SharedPostService.name);
+
+  constructor(
+    private readonly sharedPostRepository: SharedPostRepository,
+    private readonly userBadgeRepository: UserBadgeRepository,
+  ) {}
+
+  async create(input: CreateSharedPostInput, user: UserType): Promise<SharedPost> {
+    const userBadge = await this.userBadgeRepository.findOne(input.user_badge_id);
+
+    if (!userBadge) {
+      throw new NotFoundException('UserBadge not found.');
+    }
+    if (!userBadge.is_active) {
+      throw new BadRequestException('Cannot share an inactive UserBadge.');
+    }
+    if (userBadge.user_id !== user.id) {
+      throw new ForbiddenException('You can only share your own UserBadges.');
+    }
+
+    const existingSharedPost = await this.sharedPostRepository.findAnyByUserBadgeId(input.user_badge_id);
+
+    if (existingSharedPost) {
+      if (!existingSharedPost.is_deleted) {
+        throw new ConflictException('This UserBadge has already been shared and is active.');
+      } else {
+        this.logger.log(`Found soft-deleted SharedPost ${existingSharedPost.id} for UserBadge ${input.user_badge_id}. Reactivating.`);
+        try {
+          const reactivatedPost = await this.sharedPostRepository.updateAndReactivate(
+            existingSharedPost.id,
+            input.caption,
+          );
+          this.logger.log(`SharedPost reactivated and updated: ${reactivatedPost.id} by user ${user.id}`);
+          return this.transformToEntity(reactivatedPost);
+        } catch (error) {
+          this.logger.error(`Failed to reactivate SharedPost for ID ${existingSharedPost.id}: ${error.message}`, error.stack);
+          throw new BadRequestException('Failed to reactivate shared post.');
+        }
+      }
+    } else {
+      try {
+        const sharedPost = await this.sharedPostRepository.create(input, user.id);
+        this.logger.log(`SharedPost created: ${sharedPost.id} by user ${user.id}`);
+        return this.transformToEntity(sharedPost);
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          const metaTarget = error.meta?.target;
+          if (Array.isArray(metaTarget) && metaTarget.includes('user_badge_id')) {
+            this.logger.error(`P2002 conflict (unique constraint on user_badge_id) during new SharedPost creation for UserBadge ${input.user_badge_id}`, error.stack);
+            throw new ConflictException('This UserBadge might have been shared concurrently. Please try again.');
+          } else if (typeof metaTarget === 'string' && metaTarget.includes('user_badge_id')) {
+            this.logger.error(`P2002 conflict (unique constraint on user_badge_id as string target) during new SharedPost creation for UserBadge ${input.user_badge_id}`, error.stack);
+            throw new ConflictException('This UserBadge might have been shared concurrently. Please try again.');
+          }
+        }
+        this.logger.error(`Failed to create SharedPost: ${error.message}`, error.stack);
+        throw new BadRequestException('Failed to create shared post.');
+      }
+    }
+  }
+
+  async findOne(id: string): Promise<SharedPost> {
+    const sharedPost = await this.sharedPostRepository.findOne(id);
+    if (!sharedPost) {
+      throw new NotFoundException('Shared post not found.');
+    }
+    return this.transformToEntity(sharedPost);
+  }
+
+  async findAll(
+    params: PaginationParamsType,
+    filters?: SharedPostFiltersInput,
+  ): Promise<PaginatedSharedPostsResponse> {
+    const result = await this.sharedPostRepository.findAll(params, filters);
+    return {
+      ...result,
+      data: result.data.map(post => this.transformToEntity(post)),
+    };
+  }
+
+  async update(id: string, input: UpdateSharedPostInput, user: UserType): Promise<SharedPost> {
+    const sharedPost = await this.sharedPostRepository.findOneWithAnyStatus(id); // Lấy cả post đã soft-delete để kiểm tra quyền
+    if (!sharedPost || sharedPost.is_deleted) {
+      throw new NotFoundException('Shared post not found or has been deleted.');
+    }
+
+    if (sharedPost.user_badge.user_id !== user.id) {
+      throw new ForbiddenException('You can only update your own shared posts.');
+    }
+
+    try {
+      const updatedPost = await this.sharedPostRepository.update(id, input);
+      if (!updatedPost) {
+        throw new NotFoundException('Shared post not found during update.');
+      }
+      this.logger.log(`SharedPost updated: ${updatedPost.id} by user ${user.id}`);
+      return this.transformToEntity(updatedPost);
+    } catch (error) {
+      this.logger.error(`Failed to update SharedPost ${id}: ${error.message}`, error.stack);
+      throw new BadRequestException('Failed to update shared post.');
+    }
+  }
+
+  async remove(id: string, user: UserType): Promise<SharedPost> {
+    const sharedPost = await this.sharedPostRepository.findOneWithAnyStatus(id);
+    if (!sharedPost || sharedPost.is_deleted) {
+      throw new NotFoundException('Shared post not found or already deleted.');
+    }
+
+    const canDelete =
+      user.role === RoleName.Admin ||
+      user.role === RoleName.Coach ||
+      sharedPost.user_badge.user_id === user.id;
+
+    if (!canDelete) {
+      throw new ForbiddenException('You do not have permission to delete this shared post.');
+    }
+
+    try {
+      const deletedPost = await this.sharedPostRepository.delete(id);
+      if (!deletedPost) {
+        throw new NotFoundException('Shared post not found during delete.');
+      }
+      this.logger.log(`SharedPost deleted: ${deletedPost.id} by user ${user.id}`);
+      return this.transformToEntity(deletedPost);
+    } catch (error) {
+      this.logger.error(`Failed to delete SharedPost ${id}: ${error.message}`, error.stack);
+      throw new BadRequestException('Failed to delete shared post.');
+    }
+  }
+
+  private transformToEntity(dbPost: any): SharedPost {
+    return {
+      id: dbPost.id,
+      user_badge_id: dbPost.user_badge_id,
+      caption: dbPost.caption,
+      likes_count: dbPost.likes_count,
+      comments_count: dbPost.comments_count,
+      is_deleted: dbPost.is_deleted,
+      created_at: dbPost.created_at,
+      updated_at: dbPost.updated_at,
+      user_badge: {
+        id: dbPost.user_badge.id,
+        user_id: dbPost.user_badge.user_id,
+        badge_id: dbPost.user_badge.badge_id,
+        awarded_at: dbPost.user_badge.awarded_at,
+        is_active: dbPost.user_badge.is_active,
+        created_at: dbPost.user_badge.created_at,
+        updated_at: dbPost.user_badge.updated_at,
+        badge: {
+          id: dbPost.user_badge.badge.id,
+          name: dbPost.user_badge.badge.name,
+          description: dbPost.user_badge.badge.description,
+          icon_url: dbPost.user_badge.badge.icon_url,
+          requirements: dbPost.user_badge.badge.requirements ? JSON.stringify(dbPost.user_badge.badge.requirements) : undefined,
+          is_active: dbPost.user_badge.badge.is_active,
+          sort_order: dbPost.user_badge.badge.sort_order,
+          created_at: dbPost.user_badge.badge.created_at,
+          updated_at: dbPost.user_badge.badge.updated_at,
+          badge_type: dbPost.user_badge.badge.badge_type,
+        },
+        user: dbPost.user_badge.user,
+      },
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing shared posts in the application. It includes the addition of a `SharedPostModule`, which provides functionality for creating, updating, deleting, and querying shared posts. The module integrates with existing components such as `UserBadgeModule` and utilizes GraphQL for API interactions. Below are the most important changes grouped by theme:

### Module Integration:
* Added `SharedPostModule` to the application by importing it in `src/app.module.ts`. This enables the module to be part of the app's dependency tree. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R31) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R74)

### Data Models and DTOs:
* Created `SharedPost` entity in `src/routes/shared-post/entities/shared-post.entity.ts` to represent shared posts, including fields for captions, likes, comments, and timestamps.
* Added DTOs for handling shared post requests (`CreateSharedPostInput`, `UpdateSharedPostInput`, `SharedPostFiltersInput`) and responses (`PaginatedSharedPostsResponse`). [[1]](diffhunk://#diff-979cf33e85459160777223752880a5d5e4ba0593645f3cfeb7e3fff997f255a4R1-R16) [[2]](diffhunk://#diff-ce995c935118d257a871325b5abe06c159bb91d878eb9aee205a0eb60ea1f27bR1-R11) [[3]](diffhunk://#diff-9eb294c38c1870e0c51f1e9d0fa21e9d15a7370c33c39e9e553d957d8d7f5520R1-R20) [[4]](diffhunk://#diff-92ef45d243f1d9382275cee162359f077e3e5f0fd646e002cdebedd96a457435R1-R20)

### Repository and Service Implementation:
* Implemented `SharedPostRepository` in `src/routes/shared-post/shared-post.repository.ts` for database operations related to shared posts, including CRUD operations and filtering.
* Developed `SharedPostService` in `src/routes/shared-post/shared-post.service.ts` to handle business logic for shared posts, such as validation, permissions, and transformations.

### GraphQL Resolver:
* Added `SharedPostResolver` in `src/routes/shared-post/shared-post.resolver.ts` to expose GraphQL mutations and queries for managing shared posts, including creation, update, deletion, and retrieval.

### Unit Tests:
* Introduced unit tests for `SharedPostService` and `SharedPostResolver` to ensure proper functionality and integration. [[1]](diffhunk://#diff-cba92c7b44bf5c58284d6888257de615565fecee0c8b78b4e9a8f88d86e83067R1-R18) [[2]](diffhunk://#diff-a0f31e00616a01297aa99ec9eb65fddb814ad9567b1f92c9ee126535fc496596R1-R19)