### PR TITLE
feat(post-comment): add post comment functionality

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -33,6 +33,7 @@ import { UserBadgeModule } from './routes/user-badge/user-badge.module';
 import { BadgeAwardModule } from './routes/badge-award/badge-award.module';
 import { SharedPostModule } from './routes/shared-post/shared-post.module';
 import { PostLikeModule } from './routes/post-like/post-like.module';
+import { PostCommentModule } from './routes/post-comment/post-comment.module';
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import { PostLikeModule } from './routes/post-like/post-like.module';
     BadgeAwardModule,
     SharedPostModule,
     PostLikeModule,
+    PostCommentModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/routes/post-comment/dto/request/create-post-comment.input.ts
+++ b/src/routes/post-comment/dto/request/create-post-comment.input.ts
@@ -1,0 +1,21 @@
+import { InputType, Field, ID } from '@nestjs/graphql'
+import { IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator'
+
+@InputType()
+export class CreatePostCommentInput {
+  @Field(() => ID, { description: 'ID of the SharedPost to comment on' })
+  @IsNotEmpty()
+  @IsUUID()
+  shared_post_id: string;
+
+  @Field(() => String)
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(1000)
+  content: string;
+
+  @Field(() => ID, { nullable: true, description: 'ID of the parent comment if this is a reply' })
+  @IsOptional()
+  @IsUUID()
+  parent_comment_id?: string;
+}

--- a/src/routes/post-comment/dto/request/post-comment-filter.input.ts
+++ b/src/routes/post-comment/dto/request/post-comment-filter.input.ts
@@ -1,0 +1,20 @@
+import { Field, ID, InputType } from '@nestjs/graphql'
+import { IsOptional, IsUUID } from 'class-validator'
+
+@InputType()
+export class PostCommentFiltersInput {
+  @Field(() => ID, { nullable: true, description: 'Filter by shared post ID' })
+  @IsOptional()
+  @IsUUID()
+  shared_post_id?: string;
+
+  @Field(() => ID, { nullable: true, description: 'Filter by user ID' })
+  @IsOptional()
+  @IsUUID()
+  user_id?: string;
+
+  @Field(() => ID, { nullable: true, description: 'Filter by parent comment ID (to get direct replies)' })
+  @IsOptional()
+  @IsUUID()
+  parent_comment_id?: string;
+}

--- a/src/routes/post-comment/dto/request/update-post-comment.input.ts
+++ b/src/routes/post-comment/dto/request/update-post-comment.input.ts
@@ -1,0 +1,11 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator'
+
+@InputType()
+export class UpdatePostCommentInput {
+  @Field(() => String)
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(1000)
+  content: string;
+}

--- a/src/routes/post-comment/dto/response/paginated-post-comment.response.ts
+++ b/src/routes/post-comment/dto/response/paginated-post-comment.response.ts
@@ -1,0 +1,20 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+import { PostComment } from '../../entities/post-comment.entity'
+
+@ObjectType()
+export class PaginatedPostCommentsResponse {
+  @Field(() => [PostComment])
+  data: PostComment[];
+
+  @Field(() => Int)
+  total: number;
+
+  @Field(() => Int)
+  page: number;
+
+  @Field(() => Int)
+  limit: number;
+
+  @Field(() => Boolean)
+  hasNext: boolean;
+}

--- a/src/routes/post-comment/entities/post-comment.entity.ts
+++ b/src/routes/post-comment/entities/post-comment.entity.ts
@@ -1,0 +1,42 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql'
+import { SharedPost } from '../../shared-post/entities/shared-post.entity'
+import { User } from '../../user/entities/user.entity'
+
+@ObjectType()
+export class PostComment {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID, { description: 'ID of the shared post being commented on' })
+  shared_post_id: string;
+
+  @Field(() => SharedPost, { description: 'The shared post being commented on' })
+  shared_post: SharedPost;
+
+  @Field(() => ID, { description: 'ID of the user who wrote the comment' })
+  user_id: string;
+
+  @Field(() => User, { description: 'The user who wrote the comment' })
+  user: User;
+
+  @Field(() => ID, { nullable: true, description: 'ID of the parent comment if this is a reply' })
+  parent_comment_id?: string | null;
+
+  @Field(() => PostComment, { nullable: true, description: 'The parent comment if this is a reply' })
+  parent_comment?: PostComment | null;
+
+  @Field(() => [PostComment], { nullable: 'itemsAndList', description: 'Replies to this comment' })
+  replies?: PostComment[];
+
+  @Field(() => String)
+  content: string;
+
+  @Field(() => Boolean, { description: 'Indicates if the comment is soft-deleted' })
+  is_deleted: boolean;
+
+  @Field(() => Date)
+  created_at: Date;
+
+  @Field(() => Date)
+  updated_at: Date;
+}

--- a/src/routes/post-comment/post-comment.module.ts
+++ b/src/routes/post-comment/post-comment.module.ts
@@ -1,0 +1,18 @@
+import { forwardRef, Module } from '@nestjs/common'
+import { PostCommentService } from './post-comment.service';
+import { PostCommentResolver } from './post-comment.resolver';
+import { SharedPostModule } from '../shared-post/shared-post.module'
+import { GuardModule } from '../../shared/guards/guard.module'
+import { SupabaseModule } from '../../shared/modules/supabase.module'
+import { PostCommentRepository } from './post-comment.repository'
+
+@Module({
+  imports: [
+    GuardModule,
+    SupabaseModule,
+    forwardRef(() => SharedPostModule),
+  ],
+  providers: [PostCommentResolver, PostCommentService, PostCommentRepository],
+  exports: [PostCommentService, PostCommentRepository],
+})
+export class PostCommentModule {}

--- a/src/routes/post-comment/post-comment.repository.ts
+++ b/src/routes/post-comment/post-comment.repository.ts
@@ -1,0 +1,188 @@
+import { Injectable } from '@nestjs/common'
+import { Prisma } from '@prisma/client'
+import { PrismaService } from 'src/shared/services/prisma.service'
+import { CreatePostCommentInput } from './dto/request/create-post-comment.input'
+import { PaginationParamsType } from '../../shared/models/pagination.model'
+import { UpdatePostCommentInput } from './dto/request/update-post-comment.input'
+
+@Injectable()
+export class PostCommentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: CreatePostCommentInput, userId: string) {
+    return this.prisma.postComment.create({
+      data: {
+        shared_post_id: data.shared_post_id,
+        user_id: userId,
+        content: data.content,
+        parent_comment_id: data.parent_comment_id,
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findOne(id: string) {
+    return this.prisma.postComment.findUnique({
+      where: { id, is_deleted: false },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findOneWithAnyStatus(id: string) {
+    return this.prisma.postComment.findUnique({
+      where: { id },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async findAllForPost(
+    sharedPostId: string,
+    params: PaginationParamsType,
+  ) {
+    const { page, limit, orderBy = 'created_at', sortOrder = 'asc' } = params;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.PostCommentWhereInput = {
+      shared_post_id: sharedPostId,
+      is_deleted: false,
+      parent_comment_id: null,
+    };
+
+    const [data, total] = await this.prisma.$transaction([
+      this.prisma.postComment.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { [orderBy]: sortOrder },
+        include: this.getDefaultIncludes(0),
+      }),
+      this.prisma.postComment.count({ where }),
+    ]);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      hasNext: total > page * limit,
+    };
+  }
+
+  async findAllActiveDescendantIds(
+    parentCommentId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<string[]> {
+    const prismaClient = tx || this.prisma;
+    const allDescendantIds: string[] = [];
+    let currentLevelIdsToSearch = [parentCommentId];
+
+    while (currentLevelIdsToSearch.length > 0) {
+      const children = await prismaClient.postComment.findMany({
+        where: {
+          parent_comment_id: { in: currentLevelIdsToSearch },
+          is_deleted: false,
+        },
+        select: { id: true },
+      });
+
+      const foundChildIds = children.map(c => c.id);
+      if (foundChildIds.length === 0) {
+        break;
+      }
+
+      allDescendantIds.push(...foundChildIds);
+      currentLevelIdsToSearch = foundChildIds;
+    }
+    return allDescendantIds;
+  }
+
+  async update(id: string, data: UpdatePostCommentInput) {
+    return this.prisma.postComment.update({
+      where: { id, is_deleted: false },
+      data: {
+        content: data.content,
+        updated_at: new Date(),
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async delete(id: string, tx?: Prisma.TransactionClient) {
+    const prismaClient = tx || this.prisma;
+    return prismaClient.postComment.update({
+      where: { id, is_deleted: false },
+      data: {
+        is_deleted: true,
+        updated_at: new Date(),
+      },
+      include: this.getDefaultIncludes(),
+    });
+  }
+
+  async deleteMany(ids: string[], tx?: Prisma.TransactionClient) {
+    const prismaClient = tx || this.prisma;
+    return prismaClient.postComment.updateMany({
+      where: {
+        id: { in: ids },
+        is_deleted: false,
+      },
+      data: {
+        is_deleted: true,
+        updated_at: new Date(),
+      },
+    });
+  }
+
+  async countActiveCommentsForPost(sharedPostId: string, tx?: Prisma.TransactionClient): Promise<number> {
+    const prismaClient = tx || this.prisma;
+    return prismaClient.postComment.count({
+      where: {
+        shared_post_id: sharedPostId,
+        is_deleted: false,
+      },
+    });
+  }
+
+  private getDefaultIncludes(depth = 0): Prisma.PostCommentInclude {
+    const include: Prisma.PostCommentInclude = {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          user_name: true,
+          avatar_url: true,
+        },
+      },
+    };
+
+    if (depth < 2) {
+      include.replies = {
+        where: { is_deleted: false },
+        orderBy: { created_at: 'asc' },
+        include: this.getReplyIncludes(depth + 1),
+      };
+    }
+    return include;
+  }
+
+  private getReplyIncludes(depth = 0): Prisma.PostCommentInclude {
+    const include: Prisma.PostCommentInclude = {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          user_name: true,
+          avatar_url: true,
+        },
+      },
+    };
+    if (depth < 2) {
+      include.replies = {
+        where: { is_deleted: false },
+        orderBy: { created_at: 'asc' },
+        include: this.getReplyIncludes(depth + 1),
+      };
+    }
+    return include;
+  }
+}

--- a/src/routes/post-comment/post-comment.resolver.spec.ts
+++ b/src/routes/post-comment/post-comment.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostCommentResolver } from './post-comment.resolver';
+import { PostCommentService } from './post-comment.service';
+
+describe('PostCommentResolver', () => {
+  let resolver: PostCommentResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostCommentResolver, PostCommentService],
+    }).compile();
+
+    resolver = module.get<PostCommentResolver>(PostCommentResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/src/routes/post-comment/post-comment.resolver.ts
+++ b/src/routes/post-comment/post-comment.resolver.ts
@@ -1,0 +1,70 @@
+import { Resolver, Query, Mutation, Args, Int, ResolveField, Parent, ID } from '@nestjs/graphql'
+import { PostCommentService } from './post-comment.service';
+import { PostComment } from './entities/post-comment.entity';
+import { CreatePostCommentInput } from './dto/request/create-post-comment.input';
+import { UpdatePostCommentInput } from './dto/request/update-post-comment.input';
+import { UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
+import { User } from '../../shared/decorators/current-user.decorator'
+import { UserType } from '../../shared/models/share-user.model'
+import { PaginatedPostCommentsResponse } from './dto/response/paginated-post-comment.response'
+import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
+
+@Resolver(() => PostComment)
+@UseGuards(JwtAuthGuard)
+export class PostCommentResolver {
+  constructor(
+    private readonly postCommentService: PostCommentService,
+  ) {}
+
+  @Mutation(() => PostComment, { description: 'Create a new comment on a shared post.' })
+  async createPostComment(
+    @Args('input') input: CreatePostCommentInput,
+    @User() currentUser: UserType,
+  ): Promise<PostComment> {
+    return this.postCommentService.createComment(input, currentUser);
+  }
+
+  @Query(() => PaginatedPostCommentsResponse, { name: 'postComments', description: 'Get comments for a shared post.' })
+  async getPostComments(
+    @Args('sharedPostId', { type: () => ID }) sharedPostId: string,
+    @Args('params', { type: () => PaginationParamsInput, nullable: true, defaultValue: { page: 1, limit: 10, orderBy: 'created_at', sortOrder: 'asc' } })
+    params: PaginationParamsInput,
+  ): Promise<PaginatedPostCommentsResponse> {
+    return this.postCommentService.getCommentsForPost(sharedPostId, params);
+  }
+
+  @ResolveField('parent_comment', () => PostComment, { nullable: true })
+  async getParentComment(@Parent() comment: PostComment): Promise<PostComment | null> {
+    if (!comment.parent_comment_id) {
+      return null;
+    }
+    return this.postCommentService.findCommentById(comment.parent_comment_id);
+  }
+
+  @ResolveField('replies', () => [PostComment], { nullable: 'itemsAndList' })
+  getReplies(@Parent() comment: PostComment): PostComment[] {
+    if (!comment.id) return [];
+    if (comment.replies && comment.replies.length > 0) {
+      return comment.replies;
+    }
+    return [];
+  }
+
+  @Mutation(() => PostComment, { description: 'Update an existing comment.' })
+  async updatePostComment(
+    @Args('commentId', { type: () => ID }) commentId: string,
+    @Args('input') input: UpdatePostCommentInput,
+    @User() currentUser: UserType,
+  ): Promise<PostComment> {
+    return this.postCommentService.updateComment(commentId, input, currentUser);
+  }
+
+  @Mutation(() => PostComment, { description: 'Delete a comment.' })
+  async deletePostComment(
+    @Args('commentId', { type: () => ID }) commentId: string,
+    @User() currentUser: UserType,
+  ): Promise<PostComment> {
+    return this.postCommentService.deleteComment(commentId, currentUser);
+  }
+}

--- a/src/routes/post-comment/post-comment.service.spec.ts
+++ b/src/routes/post-comment/post-comment.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostCommentService } from './post-comment.service';
+
+describe('PostCommentService', () => {
+  let service: PostCommentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostCommentService],
+    }).compile();
+
+    service = module.get<PostCommentService>(PostCommentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/routes/post-comment/post-comment.service.ts
+++ b/src/routes/post-comment/post-comment.service.ts
@@ -1,0 +1,189 @@
+import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { CreatePostCommentInput } from './dto/request/create-post-comment.input';
+import { UpdatePostCommentInput } from './dto/request/update-post-comment.input'
+import { PostComment } from './entities/post-comment.entity'
+import { PaginationParamsType } from 'src/shared/models/pagination.model'
+import { PaginatedPostCommentsResponse } from './dto/response/paginated-post-comment.response'
+import { RoleName } from 'src/shared/constants/role.constant'
+import { UserType } from 'src/shared/models/share-user.model';
+import { PrismaService } from '../../shared/services/prisma.service'
+import { PostCommentRepository } from './post-comment.repository'
+import { SharedPostRepository } from '../shared-post/shared-post.repository'
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class PostCommentService {
+  private readonly logger = new Logger(PostCommentService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly postCommentRepository: PostCommentRepository,
+    private readonly sharedPostRepository: SharedPostRepository,
+  ) {}
+
+  async createComment(input: CreatePostCommentInput, user: UserType): Promise<PostComment> {
+    return this.prisma.$transaction(async (tx) => {
+      const sharedPost = await tx.sharedPost.findUnique({
+        where: { id: input.shared_post_id, is_deleted: false },
+      });
+      if (!sharedPost) {
+        throw new NotFoundException('Shared post not found or has been deleted.');
+      }
+
+      if (input.parent_comment_id) {
+        const parentComment = await tx.postComment.findUnique({
+          where: { id: input.parent_comment_id, is_deleted: false },
+        });
+        if (!parentComment) {
+          throw new NotFoundException('Parent comment not found or has been deleted.');
+        }
+        if (parentComment.shared_post_id !== input.shared_post_id) {
+          throw new BadRequestException('Parent comment does not belong to the same shared post.');
+        }
+      }
+
+      const newComment = await tx.postComment.create({
+        data: {
+          shared_post_id: input.shared_post_id,
+          user_id: user.id,
+          content: input.content,
+          parent_comment_id: input.parent_comment_id,
+        },
+        include: {
+          user: { select: { id: true, name: true, user_name: true, avatar_url: true } },
+          // replies: true,
+        }
+      });
+      this.logger.log(`PostComment created: ${newComment.id} by user ${user.id}`);
+
+      const activeCommentsCount = await tx.postComment.count({
+        where: { shared_post_id: input.shared_post_id, is_deleted: false },
+      });
+      await tx.sharedPost.update({
+        where: { id: input.shared_post_id },
+        data: { comments_count: activeCommentsCount },
+      });
+
+      return this.transformToEntity(newComment);
+    });
+  }
+
+  async getCommentsForPost(
+    sharedPostId: string,
+    params: PaginationParamsType,
+  ): Promise<PaginatedPostCommentsResponse> {
+    const post = await this.sharedPostRepository.findOne(sharedPostId);
+    if (!post) {
+      throw new NotFoundException('Shared post not found.');
+    }
+    const result = await this.postCommentRepository.findAllForPost(sharedPostId, params);
+    return {
+      ...result,
+      data: result.data.map(comment => this.transformToEntity(comment)),
+    };
+  }
+
+  async findCommentById(id: string): Promise<PostComment | null> {
+    const comment = await this.postCommentRepository.findOne(id);
+    return comment ? this.transformToEntity(comment) : null;
+  }
+
+  async updateComment(commentId: string, input: UpdatePostCommentInput, user: UserType): Promise<PostComment> {
+    const comment = await this.postCommentRepository.findOneWithAnyStatus(commentId);
+    if (!comment || comment.is_deleted) {
+      throw new NotFoundException('Comment not found or has been deleted.');
+    }
+
+    if (comment.user_id !== user.id) {
+      throw new ForbiddenException('You can only update your own comments.');
+    }
+
+    const updatedComment = await this.postCommentRepository.update(commentId, input);
+    this.logger.log(`PostComment updated: ${updatedComment.id} by user ${user.id}`);
+    return this.transformToEntity(updatedComment);
+  }
+
+  async deleteComment(commentId: string, user: UserType): Promise<PostComment> {
+    return this.prisma.$transaction(async (tx) => {
+      const prismaTransactionClient = tx as unknown as Prisma.TransactionClient;
+
+      const commentToDelete = await prismaTransactionClient.postComment.findUnique({
+        where: { id: commentId },
+        include: { user: true },
+      });
+
+      if (!commentToDelete) {
+        throw new NotFoundException('Comment not found.');
+      }
+      if (commentToDelete.is_deleted) {
+        throw new NotFoundException('Comment already deleted.');
+      }
+
+      const canDelete =
+        user.role === RoleName.Admin ||
+        user.role === RoleName.Coach ||
+        commentToDelete.user_id === user.id;
+
+      if (!canDelete) {
+        throw new ForbiddenException('You do not have permission to delete this comment.');
+      }
+
+      const descendantIds = await this.postCommentRepository.findAllActiveDescendantIds(
+        commentId,
+        prismaTransactionClient,
+      );
+
+      const allCommentIdsToDelete = [commentId, ...descendantIds];
+
+      if (allCommentIdsToDelete.length > 0) {
+        await this.postCommentRepository.deleteMany(
+          allCommentIdsToDelete,
+          prismaTransactionClient,
+        );
+      }
+
+      const activeCommentsCount = await this.postCommentRepository.countActiveCommentsForPost(
+        commentToDelete.shared_post_id,
+        prismaTransactionClient,
+      );
+      await prismaTransactionClient.sharedPost.update({
+        where: { id: commentToDelete.shared_post_id },
+        data: { comments_count: activeCommentsCount },
+      });
+
+      const finalDeletedCommentState = {
+        ...commentToDelete,
+        is_deleted: true,
+        updated_at: new Date(),
+      };
+
+      return this.transformToEntity(finalDeletedCommentState);
+    });
+  }
+
+  private transformToEntity(dbComment: any): PostComment {
+    return {
+      id: dbComment.id,
+      shared_post_id: dbComment.shared_post_id,
+      user_id: dbComment.user_id,
+      parent_comment_id: dbComment.parent_comment_id,
+      content: dbComment.content,
+      is_deleted: dbComment.is_deleted,
+      created_at: dbComment.created_at,
+      updated_at: dbComment.updated_at,
+      user: dbComment.user ? {
+        id: dbComment.user.id,
+        name: dbComment.user.name,
+        user_name: dbComment.user.user_name,
+        avatar_url: dbComment.user.avatar_url,
+        role: dbComment.user.role,
+      } : null,
+      shared_post: dbComment.shared_post ? {
+        id: dbComment.shared_post.id,
+        caption: dbComment.shared_post.caption,
+      } : null,
+      parent_comment: dbComment.parent_comment ? this.transformToEntity(dbComment.parent_comment) : null,
+      replies: dbComment.replies ? dbComment.replies.map(reply => this.transformToEntity(reply)) : [],
+    } as PostComment;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing comments on shared posts. It includes the addition of a `PostComment` module, which provides functionality for creating, updating, deleting, and querying comments, along with support for replies and pagination. Below is a summary of the most important changes grouped by theme.

### Module Integration:
* Added `PostCommentModule` to the application by importing it into `src/app.module.ts`. This enables the module's functionality across the app. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R36) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R84)
* Created `PostCommentModule` with necessary imports and exports, including services, resolvers, and repositories.

### Data Models:
* Defined the `PostComment` entity, representing a comment with fields for replies, parent comment, user, and shared post relationships.
* Added DTOs for creating, updating, filtering, and paginating comments (`CreatePostCommentInput`, `UpdatePostCommentInput`, `PostCommentFiltersInput`, and `PaginatedPostCommentsResponse`). [[1]](diffhunk://#diff-459cf7dd0095543a858d4e1f0ad83b501c7d7590447e122be959f12e015512e3R1-R21) [[2]](diffhunk://#diff-c2f974046175491556c6b4ecd66da3c4f4514021ce448825bad7dca17e42d32aR1-R20) [[3]](diffhunk://#diff-b2a9120802aa34dd2805c76be10a240c04d6d0cd9c566c90f75350ebb295b876R1-R11) [[4]](diffhunk://#diff-061b3edaedbfd8b799e12371f4da675491a011dd439cc4c6fd7908864497a116R1-R20)

### Business Logic:
* Implemented `PostCommentService` to handle operations like creating, updating, deleting, and retrieving comments, including validation and transaction management.
* Added `PostCommentRepository` to interact with the database, including methods for querying, updating, and deleting comments and their descendants.

### GraphQL Integration:
* Created `PostCommentResolver` to expose GraphQL queries and mutations for managing comments, including fields for parent comments and replies.
* Added unit tests for `PostCommentResolver` and `PostCommentService` to ensure functionality and correctness. [[1]](diffhunk://#diff-e7283ab92ffc8e9361b2bc329061cc2ecac0fea357ff1e8e87444a890ef3b8ddR1-R19) [[2]](diffhunk://#diff-b674160bbd797625b9a0d144d805cf20d1c2a5793fc7238a47eb5d791697e59fR1-R18)