### PR TITLE
Fix/update plan stage

### DIFF
--- a/src/routes/cessation-plan-template/cessation-plan-template.service.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.service.ts
@@ -6,7 +6,14 @@ import { PaginationParamsType } from '../../shared/models/pagination.model'
 import { UserType } from '../user/schema/user.schema'
 import { CessationPlanTemplateFiltersInput } from './dto/request/cessation-plan-template-filters.input'
 import { RedisServices } from 'src/shared/services/redis.service'
-import { buildCacheKey, buildOneCacheKey, deleteKeysByPattern, reviveDates } from '../../shared/utils/cache-key.util'
+import {
+  buildCacheKey,
+  buildOneCacheKey,
+  buildTrackerKey,
+  invalidateCacheForId,
+  reviveDates,
+  trackCacheKey,
+} from '../../shared/utils/cache-key.util'
 
 const CACHE_TTL = 60 * 5
 const CACHE_PREFIX = 'cessation-plan-template'
@@ -36,7 +43,7 @@ export class CessationPlanTemplateService {
         }
     )
     this.logger.log(`Cessation plan template created: ${template.id} by coach: ${user.id}`)
-    await deleteKeysByPattern(this.redisServices.getClient(), `${CACHE_PREFIX}:all*`);
+    await invalidateCacheForId(this.redisServices.getClient(), CACHE_PREFIX, 'all-lists');
     return template;
   }
 
@@ -53,6 +60,8 @@ export class CessationPlanTemplateService {
     }
     const result = await this.cessationPlanTemplateRepository.findAll(params, filters);
     await this.redisServices.getClient().set(cacheKey, JSON.stringify(result), { EX: CACHE_TTL });
+    const trackerKey = buildTrackerKey(CACHE_PREFIX, 'all-lists');
+    await trackCacheKey(this.redisServices.getClient(), trackerKey, cacheKey);
     return result;
   }
 
@@ -71,6 +80,8 @@ export class CessationPlanTemplateService {
     }
 
     await this.redisServices.getClient().set(cacheKey, JSON.stringify(template), { EX: CACHE_TTL });
+    const trackerKey = buildTrackerKey(CACHE_PREFIX, 'items');
+    await trackCacheKey(this.redisServices.getClient(), trackerKey, cacheKey);
     return template;
   }
 
@@ -90,7 +101,7 @@ export class CessationPlanTemplateService {
     const template = await this.cessationPlanTemplateRepository.update(id, data)
     this.logger.log(`Cessation plan template updated: ${template.id}`)
     await this.redisServices.getClient().del(buildOneCacheKey(CACHE_PREFIX, id));
-    await deleteKeysByPattern(this.redisServices.getClient(), `${CACHE_PREFIX}:all*`);
+    await invalidateCacheForId(this.redisServices.getClient(), CACHE_PREFIX, 'all-lists');
     return template
   }
 
@@ -103,7 +114,7 @@ export class CessationPlanTemplateService {
     const template = await this.cessationPlanTemplateRepository.delete(id)
     this.logger.log(`Cessation plan template deleted: ${template.id}`)
     await this.redisServices.getClient().del(buildOneCacheKey(CACHE_PREFIX, id));
-    await deleteKeysByPattern(this.redisServices.getClient(), `${CACHE_PREFIX}:all*`);
+    await invalidateCacheForId(this.redisServices.getClient(), CACHE_PREFIX, 'all-lists');
     return template
   }
 }


### PR DESCRIPTION
This pull request introduces caching improvements across multiple services by implementing more granular cache invalidation and tracking mechanisms. It replaces the previous `deleteKeysByPattern` method with new methods (`trackCacheKey` and `invalidateCacheForId`) to manage cache keys more efficiently. Additionally, it applies these changes to the `CessationPlanTemplateService`, `PlanStageTemplateService`, and `PlanStageService` classes.

### Caching Improvements

#### General Updates to Cache Utilities:
* [`src/shared/utils/cache-key.util.ts`](diffhunk://#diff-d2b8673d791b554c8f65c9e915d0e83667d35030c5ba1efff4dec90afb707338L18-R36): Added new methods `buildTrackerKey`, `trackCacheKey`, and `invalidateCacheForId` to support tracking and invalidating cache keys by entity ID. Removed the `deleteKeysByPattern` method, which was less efficient for cache management.

#### Updates in `CessationPlanTemplateService`:
* [`src/routes/cessation-plan-template/cessation-plan-template.service.ts`](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL39-R46): Replaced `deleteKeysByPattern` with `invalidateCacheForId` for cache invalidation. Added cache tracking using `trackCacheKey` and `buildTrackerKey` for templates and lists. [[1]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL39-R46) [[2]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbR63-R64) [[3]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbR83-R84) [[4]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL93-R104) [[5]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL106-R117)

#### Updates in `PlanStageTemplateService`:
* [`src/routes/plan-stage-template/plan-stage-template.service.ts`](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501R51-R52): Replaced `deleteKeysByPattern` with `invalidateCacheForId` for cache invalidation. Added cache tracking for individual templates and their associated data. Extended invalidation logic to handle updates that change the parent template ID. [[1]](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501R51-R52) [[2]](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501R69-R70) [[3]](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501L70-R81) [[4]](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501L98-R112) [[5]](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501L113-R131) [[6]](diffhunk://#diff-2c22813a08b0c9774ab0fffab369a02bb48c9eed57a4aac9c04b0e1af74ca501L138-R151)

#### Updates in `PlanStageService`:
* [`src/routes/plan-stage/plan-stage.service.ts`](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R50-R52): Integrated caching for individual stages and lists using `trackCacheKey` and `invalidateCacheForId`. Added logic to cache enriched stage data and invalidate cache on updates, deletions, and reordering. Improved validation for non-customizable plans to restrict updates to specific fields. [[1]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R50-R52) [[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R72-R115) [[3]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L124-R166) [[4]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R178-R179) [[5]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R200) [[6]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R220)

These changes enhance cache efficiency, improve data consistency, and reduce the risk of stale data across services.