### PR TITLE
Feature/leaderboard

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,7 @@ import { ChatModule } from './routes/chat/chat.module';
 import { createWebSocketContext } from './shared/config/websocket.config';
 import { PrismaService } from './shared/services/prisma.service';
 import { SupabaseModule } from './shared/modules/supabase.module';
+import { LeaderboardModule } from './routes/leaderboard/leaderboard.module'
 
 @Module({
   imports: [
@@ -110,6 +111,7 @@ import { SupabaseModule } from './shared/modules/supabase.module';
     PostLikeModule,
     PostCommentModule,
     ChatModule,
+    LeaderboardModule
   ],
   controllers: [AppController],
   providers: [

--- a/src/routes/leaderboard/dto/response/leaderboard-stats.response.ts
+++ b/src/routes/leaderboard/dto/response/leaderboard-stats.response.ts
@@ -1,0 +1,13 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+export class LeaderboardStats {
+  @Field(() => Int)
+  totalUsers: number;
+
+  @Field()
+  averageStreak: number;
+
+  @Field(() => Int)
+  topStreak: number;
+}

--- a/src/routes/leaderboard/dto/response/paginated-streak-leaderboard.response.ts
+++ b/src/routes/leaderboard/dto/response/paginated-streak-leaderboard.response.ts
@@ -1,0 +1,14 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+import { StreakLeaderboardEntry } from './streak-leaderboard-entry.response'
+
+@ObjectType()
+export class PaginatedStreakLeaderboard {
+  @Field(() => [StreakLeaderboardEntry])
+  data: StreakLeaderboardEntry[];
+
+  @Field(() => Int)
+  total: number;
+
+  @Field(() => StreakLeaderboardEntry, { nullable: true, description: "Current user's rank, if they are on the leaderboard." })
+  myRank?: StreakLeaderboardEntry;
+}

--- a/src/routes/leaderboard/dto/response/streak-leaderboard-entry.response.ts
+++ b/src/routes/leaderboard/dto/response/streak-leaderboard-entry.response.ts
@@ -1,0 +1,19 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+export class StreakLeaderboardEntry {
+  @Field(() => Int)
+  rank: number;
+
+  @Field()
+  userId: string;
+
+  @Field()
+  userName: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field(() => Int)
+  streak: number;
+}

--- a/src/routes/leaderboard/leaderboard.module.ts
+++ b/src/routes/leaderboard/leaderboard.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { LeaderboardService } from './leaderboard.service';
+import { LeaderboardResolver } from './leaderboard.resolver';
+import { RedisServices } from 'src/shared/services/redis.service';
+import { GuardModule } from '../../shared/guards/guard.module'
+import { SupabaseModule } from '../../shared/modules/supabase.module'
+
+@Module({
+  imports: [
+    GuardModule,
+    SupabaseModule
+  ],
+  providers: [LeaderboardService, LeaderboardResolver, RedisServices],
+  exports: [LeaderboardService],
+})
+export class LeaderboardModule {} 

--- a/src/routes/leaderboard/leaderboard.resolver.ts
+++ b/src/routes/leaderboard/leaderboard.resolver.ts
@@ -1,0 +1,89 @@
+import { Resolver, Query, Args, Int } from '@nestjs/graphql';
+import { LeaderboardService } from './leaderboard.service';
+import { UserType } from '../user/schema/user.schema'
+import { User } from '../../shared/decorators/current-user.decorator'
+import { PrismaService } from '../../shared/services/prisma.service'
+import { LeaderboardStats } from './dto/response/leaderboard-stats.response'
+import { PaginatedStreakLeaderboard } from './dto/response/paginated-streak-leaderboard.response'
+import { StreakLeaderboardEntry } from './dto/response/streak-leaderboard-entry.response'
+import { UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
+
+@Resolver()
+export class LeaderboardResolver {
+  constructor(
+    private readonly leaderboardService: LeaderboardService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  @Query(() => PaginatedStreakLeaderboard)
+  async streakLeaderboard(
+    @Args('limit', { type: () => Int, defaultValue: 10 }) limit: number,
+    @Args('offset', { type: () => Int, defaultValue: 0 }) offset: number,
+    @User() currentUser: UserType,
+  ): Promise<PaginatedStreakLeaderboard> {
+    const rawLeaderboard = await this.leaderboardService.getTopStreaks(limit, offset);
+    if (rawLeaderboard.length === 0) {
+      return { data: [], total: 0 };
+    }
+
+    const userIds = rawLeaderboard.map(entry => entry.userId);
+    const users = await this.prisma.user.findMany({
+      where: { id: { in: userIds } },
+      select: { id: true, user_name: true, avatar_url: true },
+    });
+    const userMap = new Map(users.map(u => [u.id, u]));
+
+    const data = rawLeaderboard.map((entry, index) => {
+      const user = userMap.get(entry.userId);
+      return {
+        rank: offset + index + 1,
+        userId: entry.userId,
+        userName: user?.user_name || 'Unknown User',
+        avatarUrl: user?.avatar_url,
+        streak: entry.score,
+      };
+    });
+
+    let myRank: StreakLeaderboardEntry | undefined;
+    const myStreakData = await this.leaderboardService.getUserStreakWithRank(currentUser.id);
+
+    if (myStreakData) {
+      myRank = {
+        rank: myStreakData.rank,
+        userId: currentUser.id,
+        userName: currentUser.user_name,
+        avatarUrl: currentUser.avatar_url,
+        streak: myStreakData.streak,
+      };
+    }
+
+    const stats = await this.leaderboardService.getStreakLeaderboardStats();
+
+    return { data, total: stats.totalUsers, myRank };
+  }
+
+  @Query(() => StreakLeaderboardEntry, {
+    nullable: true, description: "Get current user's streak and rank."
+  })
+  @UseGuards(JwtAuthGuard)
+  async myStreakRank(@User() currentUser: UserType): Promise<StreakLeaderboardEntry | null> {
+    const streakData = await this.leaderboardService.getUserStreakWithRank(currentUser.id);
+    if (!streakData) {
+      return null;
+    }
+
+    return {
+      rank: streakData.rank,
+      userId: currentUser.id,
+      userName: currentUser.user_name,
+      avatarUrl: currentUser.avatar_url,
+      streak: streakData.streak,
+    };
+  }
+
+  @Query(() => LeaderboardStats)
+  async streakLeaderboardStats(): Promise<LeaderboardStats> {
+    return this.leaderboardService.getStreakLeaderboardStats();
+  }
+}

--- a/src/routes/leaderboard/leaderboard.service.ts
+++ b/src/routes/leaderboard/leaderboard.service.ts
@@ -1,0 +1,154 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { RedisServices } from '../../shared/services/redis.service'
+
+export const LEADERBOARD_KEYS = {
+  MAIN_SCORE: 'leaderboard:main',
+  STREAK: 'leaderboard:streak',
+  // STAGES_COMPLETED: 'leaderboard:stages',
+  // BADGES_EARNED: 'leaderboard:badges',
+} as const;
+
+type LeaderboardKey = typeof LEADERBOARD_KEYS[keyof typeof LEADERBOARD_KEYS];
+
+@Injectable()
+export class LeaderboardService {
+  private readonly logger = new Logger(LeaderboardService.name);
+
+  constructor(private readonly redisServices: RedisServices) {}
+
+  private async updateScore(key: LeaderboardKey, userId: string, score: number): Promise<void> {
+    const startTime = Date.now();
+
+    try {
+      await this.redisServices.getClient().zAdd(key, [{ score, value: userId }]);
+
+      const duration = Date.now() - startTime;
+      this.logger.log(`Updated ${key} for user ${userId}: ${score} (${duration}ms)`);
+
+      // Log milestone achievements
+      if (key === LEADERBOARD_KEYS.STREAK && score > 0 && score % 7 === 0) {
+        this.logger.log(`🎉 User ${userId} reached ${score}-day streak milestone!`);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to update ${key} for user ${userId}:`, error);
+      throw error;
+    }
+  }
+
+  private async getTop(key: LeaderboardKey, limit: number, offset = 0): Promise<{ userId: string; score: number }[]> {
+    const result = await this.redisServices.getClient().zRangeWithScores(
+      key,
+      offset,
+      offset + limit - 1,
+      { REV: true }
+    );
+    return result.map((entry) => ({
+      userId: entry.value,
+      score: entry.score,
+    }));
+  }
+
+  private async getRank(key: LeaderboardKey, userId: string): Promise<number | null> {
+    const rank = await this.redisServices.getClient().zRevRank(key, userId);
+    return typeof rank === 'number' ? rank + 1 : null;
+  }
+
+  private async getScore(key: LeaderboardKey, userId: string): Promise<number | null> {
+    const score = await this.redisServices.getClient().zScore(key, userId);
+    return score !== null ? score : null;
+  }
+
+  private async getTotalUsers(key: LeaderboardKey): Promise<number> {
+    return this.redisServices.getClient().zCard(key);
+  }
+
+  // --- API công khai cho Streak Leaderboard ---
+  async updateUserStreak(userId: string, streak: number): Promise<void> {
+    await this.updateScore(LEADERBOARD_KEYS.STREAK, userId, streak);
+  }
+
+  async getTopStreaks(limit: number, offset = 0): Promise<{ userId: string; score: number }[]> {
+    return this.getTop(LEADERBOARD_KEYS.STREAK, limit, offset);
+  }
+
+  async getUserStreakRank(userId: string): Promise<number | null> {
+    return this.getRank(LEADERBOARD_KEYS.STREAK, userId);
+  }
+
+  async getUserStreak(userId: string): Promise<number | null> {
+    return this.getScore(LEADERBOARD_KEYS.STREAK, userId);
+  }
+
+  async getStreakLeaderboardStats(): Promise<{
+    totalUsers: number;
+    averageStreak: number;
+    topStreak: number;
+  }> {
+    const key = LEADERBOARD_KEYS.STREAK;
+    const client = this.redisServices.getClient();
+
+    const [totalUsers, topResult] = await Promise.all([
+      this.getTotalUsers(key),
+      client.zRangeWithScores(key, 0, 0, { REV: true })
+    ]);
+
+    const topStreak = topResult.length > 0 ? topResult[0].score : 0;
+
+    let averageStreak = 0;
+    if (totalUsers > 0) {
+      const allScores = await client.zRangeWithScores(key, 0, -1);
+      const sumScores = allScores.reduce((sum, entry) => sum + entry.score, 0);
+      averageStreak = sumScores / totalUsers;
+    }
+
+    return {
+      totalUsers,
+      averageStreak: Math.round(averageStreak * 100) / 100,
+      topStreak
+    };
+  }
+
+  // --- API công khai cho Main Score Leaderboard---
+  // async updateUserMainScore(userId: string, score: number): Promise<void> {
+  //   await this.updateScore(LEADERBOARD_KEYS.MAIN_SCORE, userId, score);
+  // }
+
+  // async getTopMainScores(limit: number, offset = 0): Promise<{ userId: string; score: number }[]> {
+  //   return this.getTop(LEADERBOARD_KEYS.MAIN_SCORE, limit, offset);
+  // }
+
+  // async getUserMainScoreRank(userId: string): Promise<number | null> {
+  //   return this.getRank(LEADERBOARD_KEYS.MAIN_SCORE, userId);
+  // }
+
+  // async getUserMainScore(userId: string): Promise<number | null> {
+  //   return this.getScore(LEADERBOARD_KEYS.MAIN_SCORE, userId);
+  // }
+
+  // --- Batch operations ---
+  async batchUpdateStreaks(updates: { userId: string; streak: number }[]): Promise<void> {
+    if (updates.length === 0) return;
+
+    const client = this.redisServices.getClient();
+    const pipeline = client.multi();
+
+    updates.forEach(({ userId, streak }) => {
+      pipeline.zAdd(LEADERBOARD_KEYS.STREAK, [{ score: streak, value: userId }]);
+    });
+
+    await pipeline.exec();
+    this.logger.log(`Batch updated ${updates.length} streak scores`);
+  }
+
+  // --- Utility methods ---
+  async getUserStreakWithRank(userId: string): Promise<{ streak: number; rank: number } | null> {
+    const [streak, rank] = await Promise.all([
+      this.getUserStreak(userId),
+      this.getUserStreakRank(userId)
+    ]);
+
+    if (streak === null || rank === null) return null;
+
+    return { streak, rank };
+  }
+}

--- a/src/routes/progress-record/progress-record.module.ts
+++ b/src/routes/progress-record/progress-record.module.ts
@@ -6,13 +6,15 @@ import { CessationPlanModule } from '../cessation-plan/cessation-plan.module'
 import { ProgressRecordRepository } from './progress-record.repository'
 import { SupabaseModule } from '../../shared/modules/supabase.module'
 import { BadgeAwardModule } from '../badge-award/badge-award.module'
+import { LeaderboardModule } from '../leaderboard/leaderboard.module'
 
 @Module({
   imports: [
     GuardModule,
     SupabaseModule,
     forwardRef(() => CessationPlanModule),
-    BadgeAwardModule
+    BadgeAwardModule,
+    LeaderboardModule
   ],
   providers: [
     ProgressRecordResolver,

--- a/src/routes/progress-record/progress-record.service.ts
+++ b/src/routes/progress-record/progress-record.service.ts
@@ -16,6 +16,7 @@ import { UpdateProgressRecordType } from './schema/update-progress-record.schema
 import { PaginationParamsType } from '../../shared/models/pagination.model'
 import { ProgressRecordFiltersInput } from './dto/request/progress-record-filters.input'
 import { BadgeAwardService } from '../badge-award/badge-award.service'
+import { LeaderboardService } from '../leaderboard/leaderboard.service'
 
 @Injectable()
 export class ProgressRecordService {
@@ -25,6 +26,7 @@ export class ProgressRecordService {
     private readonly progressRecordRepository: ProgressRecordRepository,
     private readonly cessationPlanRepository: CessationPlanRepository,
     private readonly badgeAwardService: BadgeAwardService,
+    private readonly leaderboardService: LeaderboardService,
   ) {}
 
   async create(data: CreateProgressRecordType, user: UserType): Promise<ProgressRecord> {
@@ -48,8 +50,12 @@ export class ProgressRecordService {
     try {
       const record = await this.progressRecordRepository.create(data);
       this.logger.log(`Progress record created: ${record.id} for plan: ${record.plan_id}`);
+      const currentStreak = await this.calculateUserStreak(user.id, record.plan_id);
+      const prevStreak = await this.leaderboardService.getUserStreak(user.id) || 0;
+      if (currentStreak !== prevStreak) {
+        await this.leaderboardService.updateUserStreak(user.id, currentStreak);
+      }
       if (data.cigarettes_smoked === 0) {
-        const currentStreak = await this.calculateUserStreak(user.id, record.plan_id);
         await this.badgeAwardService.processStreakUpdate(user.id, currentStreak);
       }
       return record as ProgressRecord;
@@ -120,9 +126,13 @@ export class ProgressRecordService {
       const updatedRecord = await this.progressRecordRepository.update(id, data);
       if (!updatedRecord) throw new NotFoundException('Progress record not found or already deleted.');
       this.logger.log(`Progress record updated: ${updatedRecord.id}`);
+      const currentStreak = await this.calculateUserStreak(user.id, updatedRecord.plan_id);
+      const prevStreak = await this.leaderboardService.getUserStreak(user.id) || 0;
+      if (currentStreak !== prevStreak) {
+        await this.leaderboardService.updateUserStreak(user.id, currentStreak);
+      }
       if (data.cigarettes_smoked === 0) {
-        const currentStreak = await this.calculateUserStreak(user.id, updatedRecord.plan_id); // Bạn cần implement hàm này
-        await this.badgeAwardService.processStreakUpdate(user.id, currentStreak); // <<< GỌI HÀM
+        await this.badgeAwardService.processStreakUpdate(user.id, currentStreak);
       }
       return updatedRecord as ProgressRecord;
     } catch (error) {
@@ -157,7 +167,6 @@ export class ProgressRecordService {
   }
 
   private async calculateUserStreak(userId: string, planId: string): Promise<number> {
-    this.logger.log(`Calculating streak for user ${userId} on plan ${planId}. Implementation needed.`);
     const records = await this.progressRecordRepository.findAll({ page: 1, limit: 1000, orderBy: 'record_date', sortOrder: 'desc' }, {planId});
     let streak = 0;
     for (const record of records.data) {


### PR DESCRIPTION
This pull request introduces a new `LeaderboardModule` to manage streak-based leaderboards, integrates it with existing services, and updates related functionality. The changes include creating the leaderboard module, defining its service and resolver, and integrating it with the `ProgressRecordService` to track and update user streaks. Below is a summary of the most important changes:

### Leaderboard Module Implementation
* **New `LeaderboardModule`**: Added a new module (`LeaderboardModule`) with its service (`LeaderboardService`) and resolver (`LeaderboardResolver`) to manage streak leaderboards. This includes Redis-based operations for managing scores, ranks, and leaderboard statistics. (`[[1]](diffhunk://#diff-928359d22ecb40b7226b8b99d0733737d270626b2a9b4573cfa8c729d87ae3e7R1-R16)`, `[[2]](diffhunk://#diff-4597b2268c53fb913faa4b5184451eb44e01304df8ae03686a70c7d0170ae2beR1-R154)`, `[[3]](diffhunk://#diff-0b9a7c44e987e54da13715c0d4067a55bf9bd2411a3e5fc297dd88717d97031cR1-R89)`)
* **DTOs for Leaderboard Responses**: Introduced `LeaderboardStats`, `PaginatedStreakLeaderboard`, and `StreakLeaderboardEntry` DTOs for GraphQL response structures. (`[[1]](diffhunk://#diff-28b5227c7ce734d3f4e611a80279c6ae9637c78d7531586be2494973633c85dfR1-R13)`, `[[2]](diffhunk://#diff-d85e02af42f6975d182f85158f43f8c487b9df3795734ebf45edfab956683a06R1-R14)`, `[[3]](diffhunk://#diff-7f952c4a781c71402b5c0635a94bc4f5fc6c8d9cd1c65c7b5461d514f0ba5c00R1-R19)`)

### Integration with Existing Services
* **Integration with `ProgressRecordService`**: Modified `ProgressRecordService` to update user streaks in the leaderboard whenever progress records are created or updated. It ensures streak consistency and triggers updates only when streaks change. (`[[1]](diffhunk://#diff-3896f78552af306ba890fe794b335997da6c9d23e3886c9ea26fdc7af41c8252L51-R58)`, `[[2]](diffhunk://#diff-3896f78552af306ba890fe794b335997da6c9d23e3886c9ea26fdc7af41c8252R129-R135)`)
* **Leaderboard Dependency Injection**: Injected `LeaderboardService` into `ProgressRecordService` and added `LeaderboardModule` as an import in `ProgressRecordModule`. (`[[1]](diffhunk://#diff-3896f78552af306ba890fe794b335997da6c9d23e3886c9ea26fdc7af41c8252R19)`, `[[2]](diffhunk://#diff-5386312d1a0fd129df3aea6197c11be25338d43e0ec4e2af3fab143174f5bee9R9-R17)`)

### App-Wide Changes
* **App Module Updates**: Registered `LeaderboardModule` in the root `AppModule` to make it available throughout the application. (`[[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R42)`, `[[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R114)`)