### PR TITLE
Develop

### DIFF
--- a/src/routes/badge-type/badge-type.resolver.ts
+++ b/src/routes/badge-type/badge-type.resolver.ts
@@ -8,7 +8,7 @@ import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard'
 import { RolesGuard } from 'src/shared/guards/roles.guard'
 import { Roles } from 'src/shared/decorators/roles.decorator'
 import { RoleName } from 'src/shared/constants/role.constant';
-import {User} from "../../shared/decorators/current-user.decorator";
+import {CurrentUser} from "../../shared/decorators/current-user.decorator";
 import {UserType} from "../user/schema/user.schema";
 import {PaginatedBadgeTypesResponse} from "./dto/response/paginated-badge-type.response";
 import {PaginationParamsInput} from "../../shared/models/dto/request/pagination-params.input";
@@ -24,7 +24,7 @@ export class BadgeTypeResolver {
   @Roles(RoleName.Admin)
   async createBadgeType(
     @Args('input') input: CreateBadgeTypeInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<BadgeType> {
     return this.badgeTypeService.create(input, user);
   }
@@ -48,7 +48,7 @@ export class BadgeTypeResolver {
     params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => BadgeTypeFiltersInput })
     filters: BadgeTypeFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PaginatedBadgeTypesResponse> {
     return this.badgeTypeService.findAll(params, filters, user);
   }
@@ -56,7 +56,7 @@ export class BadgeTypeResolver {
   @Query(() => String, { description: 'Get badge type statistics for admin/coach' })
   @UseGuards(RolesGuard)
   @Roles(RoleName.Admin, RoleName.Coach)
-  async badgeTypeStatistics(@User() user: UserType): Promise<string> {
+  async badgeTypeStatistics(@CurrentUser() user: UserType): Promise<string> {
     const stats = await this.badgeTypeService.getStatistics(user);
     return JSON.stringify(stats);
   }
@@ -67,7 +67,7 @@ export class BadgeTypeResolver {
   async updateBadgeType(
     @Args('id', { type: () => ID }) id: string,
     @Args('input') input: UpdateBadgeTypeInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<BadgeType> {
     return this.badgeTypeService.update(id, input, user);
   }
@@ -77,7 +77,7 @@ export class BadgeTypeResolver {
   @Roles(RoleName.Admin)
   async removeBadgeType(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<BadgeType> {
     return this.badgeTypeService.remove(id, user);
   }

--- a/src/routes/badge/badge.resolver.ts
+++ b/src/routes/badge/badge.resolver.ts
@@ -6,7 +6,7 @@ import { UpdateBadgeInput } from './dto/request/update-badge.input'
 import { UseGuards } from '@nestjs/common'
 import { Roles } from 'src/shared/decorators/roles.decorator';
 import { UserType } from '../user/schema/user.schema'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { RoleName } from '../../shared/constants/role.constant'
 import { RolesGuard } from '../../shared/guards/roles.guard'
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
@@ -24,7 +24,7 @@ export class BadgeResolver {
   @Roles(RoleName.Admin, RoleName.Coach)
   async createBadge(
     @Args('input') input: CreateBadgeInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<Badge> {
     return this.badgeService.create(input, user);
   }
@@ -48,7 +48,7 @@ export class BadgeResolver {
     params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => BadgeFiltersInput })
     filters: BadgeFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PaginatedBadgesResponse> {
     return this.badgeService.findAll(params, filters, user);
   }
@@ -56,7 +56,7 @@ export class BadgeResolver {
   @Query(() => String, { description: 'Get badge statistics for admin/coach' })
   @UseGuards(RolesGuard)
   @Roles(RoleName.Admin, RoleName.Coach)
-  async badgeStatistics(@User() user: UserType): Promise<string> {
+  async badgeStatistics(@CurrentUser() user: UserType): Promise<string> {
     const stats = await this.badgeService.getStatistics(user);
     return JSON.stringify(stats);
   }
@@ -67,7 +67,7 @@ export class BadgeResolver {
   async updateBadge(
     @Args('id', { type: () => ID }) id: string,
     @Args('input') input: UpdateBadgeInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<Badge> {
     return this.badgeService.update(id, input, user);
   }
@@ -77,7 +77,7 @@ export class BadgeResolver {
   @Roles(RoleName.Admin, RoleName.Coach)
   async removeBadge(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<Badge> {
     return this.badgeService.remove(id, user);
   }

--- a/src/routes/blog/blog.resolver.ts
+++ b/src/routes/blog/blog.resolver.ts
@@ -9,7 +9,7 @@ import { UseGuards } from '@nestjs/common'
 import { Roles } from '../../shared/decorators/roles.decorator'
 import { RoleName } from '../../shared/constants/role.constant'
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { FileUpload } from 'graphql-upload/processRequest.mjs'
 import { UploadScalar } from '../../shared/scalars/upload.scalar'
 import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
@@ -26,7 +26,7 @@ export class BlogResolver {
   async createBlog(
     @Args('input') input: CreateBlogInput,
     @Args({ name: 'coverImage', type: () => UploadScalar, nullable: true }) coverImage: Promise<FileUpload>,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ) {
     return this.blogService.create(input, coverImage, user.id)
   }
@@ -62,7 +62,7 @@ export class BlogResolver {
   async updateBlog(
     @Args('input') input: UpdateBlogInput,
     @Args({ name: 'coverImage', type: () => UploadScalar, nullable: true }) coverImage: Promise<FileUpload>,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ) {
     const { id, ...updateData } = input
     return this.blogService.update(id, updateData, coverImage, user.id, user.role)
@@ -71,7 +71,7 @@ export class BlogResolver {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleName.Coach, RoleName.Admin)
   @Mutation(() => Blog)
-  async removeBlog(@Args('id') id: string, @User() user: UserType) {
+  async removeBlog(@Args('id') id: string, @CurrentUser() user: UserType) {
     return this.blogService.remove(id, user.id, user.role)
   }
 }

--- a/src/routes/cessation-plan-template/cessation-plan-template.resolver.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.resolver.ts
@@ -6,7 +6,7 @@ import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
 import { RolesGuard } from '../../shared/guards/roles.guard'
 import { Roles } from '../../shared/decorators/roles.decorator'
 import { RoleName } from '../../shared/constants/role.constant'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema'
 import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
 import { PaginatedCessationPlanTemplatesResponse } from './dto/response/paginated-cessation-plan-templates.response'
@@ -22,7 +22,7 @@ export class CessationPlanTemplateResolver {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleName.Coach)
   @Mutation(() => CessationPlanTemplate)
-  async createCessationPlanTemplate(@Args('input') input: CreateCessationPlanTemplateInput, @User() user: UserType) {
+  async createCessationPlanTemplate(@Args('input') input: CreateCessationPlanTemplateInput, @CurrentUser() user: UserType) {
     return this.cessationPlanTemplateService.create(input, user)
   }
 
@@ -58,7 +58,7 @@ export class CessationPlanTemplateResolver {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleName.Coach)
   @Mutation(() => CessationPlanTemplate)
-  async removeCessationPlanTemplate(@Args('id') id: string, @User() user: UserType) {
+  async removeCessationPlanTemplate(@Args('id') id: string, @CurrentUser() user: UserType) {
     return this.cessationPlanTemplateService.remove(id, user.role)
   }
 }

--- a/src/routes/cessation-plan/cessation-plan.resolver.ts
+++ b/src/routes/cessation-plan/cessation-plan.resolver.ts
@@ -4,7 +4,7 @@ import { CessationPlanService } from './cessation-plan.service';
 import { CessationPlan } from './entities/cessation-plan.entity';
 import { CreateCessationPlanInput } from './dto/request/create-cessation-plan.input';
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard';
-import { User } from '../../shared/decorators/current-user.decorator';
+import { CurrentUser } from '../../shared/decorators/current-user.decorator';
 import { UserType } from '../user/schema/user.schema';
 import {PaginatedCessationPlansResponse} from "./dto/response/paginated-cessation-plans.response";
 import {PaginationParamsInput} from "../../shared/models/dto/request/pagination-params.input";
@@ -25,7 +25,7 @@ export class CessationPlanResolver {
   @Roles(RoleName.Member)
   async createCessationPlan(
     @Args('input') input: CreateCessationPlanInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<CessationPlan> {
     return this.cessationPlanService.create(input, user.id);
   }
@@ -35,7 +35,7 @@ export class CessationPlanResolver {
   async cessationPlans(
       @Args('params', { nullable: true }) params?: PaginationParamsInput,
       @Args('filters', { nullable: true }) filters?: CessationPlanFiltersInput,
-      @User() user?: UserType,
+      @CurrentUser() user?: UserType,
   ): Promise<PaginatedCessationPlansResponse> {
     return this.cessationPlanService.findAll(
         params || { page: 1, limit: 10, orderBy: 'created_at', sortOrder: 'desc' },
@@ -49,7 +49,7 @@ export class CessationPlanResolver {
   @UseGuards(JwtAuthGuard)
   async cessationPlan(
       @Args('id') id: string,
-      @User() user: UserType,
+      @CurrentUser() user: UserType,
   ): Promise<CessationPlan> {
     return this.cessationPlanService.findOne(id, user.role, user.id);
   }
@@ -57,7 +57,7 @@ export class CessationPlanResolver {
   @Query(() => [CessationPlan])
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleName.Member)
-  async userCessationPlans(@User() user?: UserType): Promise<CessationPlan[]> {
+  async userCessationPlans(@CurrentUser() user?: UserType): Promise<CessationPlan[]> {
     return this.cessationPlanService.findByUserId(user);
   }
 
@@ -66,7 +66,7 @@ export class CessationPlanResolver {
   @Roles(RoleName.Coach, RoleName.Admin)
   async cessationPlanStatistics(
       @Args('filters', { nullable: true }) filters?: CessationPlanFiltersInput,
-      @User() user?: UserType,
+      @CurrentUser() user?: UserType,
   ): Promise<CessationPlanStatisticsResponse> {
     return this.cessationPlanService.getStatistics(filters, user?.role, user?.id);
   }
@@ -76,7 +76,7 @@ export class CessationPlanResolver {
   @Roles(RoleName.Member)
   async updateCessationPlan(
       @Args('input') input: UpdateCessationPlanInput,
-      @User() user: UserType,
+      @CurrentUser() user: UserType,
   ): Promise<CessationPlan> {
     const { id, ...updateData } = input;
     return this.cessationPlanService.update(id, updateData, user.role, user.id);

--- a/src/routes/chat/chat.resolver.ts
+++ b/src/routes/chat/chat.resolver.ts
@@ -8,7 +8,8 @@ import { CreateChatMessageInput } from './dto/request/create-chat-message.input'
 import { ChatRepository } from './chat.repository';
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard';
 import { Inject } from '@nestjs/common';
-import { User } from 'src/shared/decorators/current-user.decorator';
+import { CurrentUser } from 'src/shared/decorators/current-user.decorator';
+import { UserType } from '../user/schema/user.schema';
 
 @Resolver(() => ChatRoom)
 @UseGuards(JwtAuthGuard)
@@ -19,14 +20,14 @@ export class ChatResolver {
   ) { }
 
   @Query(() => [ChatRoom])
-  async getAllChatRoomsByUser(@User() user: any) {
+  async getAllChatRoomsByUser(@CurrentUser() user: any) {
     return this.chatRepository.getChatRooms(user.id);
   }
 
   @Query(() => [ChatMessage])
   async getChatMessagesByRoomId(
     @Args('roomId') roomId: string,
-    @User() user: any,
+    @CurrentUser() user: any,
   ) {
     return this.chatRepository.getChatMessages(roomId, user.id);
   }
@@ -34,7 +35,7 @@ export class ChatResolver {
   @Mutation(() => ChatRoom)
   async createChatRoom(
     @Args('input') input: CreateChatRoomInput,
-    @User() user: any,
+    @CurrentUser() user: any,
   ) {
     return this.chatRepository.createChatRoom(user.id, input);
   }
@@ -42,7 +43,7 @@ export class ChatResolver {
   @Mutation(() => ChatMessage)
   async sendMessage(
     @Args('input') input: CreateChatMessageInput,
-    @User() user: any,
+    @CurrentUser() user: any,
   ) {
     const message = await this.chatRepository.createMessage(user.id, input);
 
@@ -66,7 +67,7 @@ export class ChatResolver {
   @Mutation(() => Boolean)
   async markMessagesAsRead(
     @Args('roomId') roomId: string,
-    @User() user: any,
+    @CurrentUser() user: UserType,
   ) {
     await this.chatRepository.markMessagesAsRead(roomId, user.id);
     return true;

--- a/src/routes/feedback/feedback.resolver.ts
+++ b/src/routes/feedback/feedback.resolver.ts
@@ -5,7 +5,7 @@ import { CreateFeedbackInput } from './dto/request/create-feedback.input';
 import { UpdateFeedbackInput } from './dto/request/update-feedback.input'
 import { UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema';
 import { PaginatedFeedbacksResponse } from './dto/response/paginated-feedbacks.response'
 import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
@@ -19,7 +19,7 @@ export class FeedbackResolver {
   @Mutation(() => Feedback)
   async createFeedback(
     @Args('input') input: CreateFeedbackInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<Feedback> {
     return this.feedbackService.create(input, user);
   }
@@ -38,7 +38,7 @@ export class FeedbackResolver {
     }) params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => FeedbackFiltersInput })
     filters: FeedbackFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ) {
     return this.feedbackService.findAll(params, filters, user);
   }
@@ -47,7 +47,7 @@ export class FeedbackResolver {
   async updateFeedback(
     @Args('id', { type: () => ID }) id: string,
     @Args('input') input: UpdateFeedbackInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<Feedback> {
     return this.feedbackService.update(id, input, user);
   }
@@ -55,7 +55,7 @@ export class FeedbackResolver {
   @Mutation(() => Feedback)
   async removeFeedback(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<Feedback> {
     return this.feedbackService.remove(id, user);
   }

--- a/src/routes/leaderboard/leaderboard.resolver.ts
+++ b/src/routes/leaderboard/leaderboard.resolver.ts
@@ -1,7 +1,7 @@
 import { Resolver, Query, Args, Int } from '@nestjs/graphql';
 import { LeaderboardService } from './leaderboard.service';
 import { UserType } from '../user/schema/user.schema'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { PrismaService } from '../../shared/services/prisma.service'
 import { LeaderboardStats } from './dto/response/leaderboard-stats.response'
 import { PaginatedStreakLeaderboard } from './dto/response/paginated-streak-leaderboard.response'
@@ -20,7 +20,7 @@ export class LeaderboardResolver {
   async streakLeaderboard(
     @Args('limit', { type: () => Int, defaultValue: 10 }) limit: number,
     @Args('offset', { type: () => Int, defaultValue: 0 }) offset: number,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<PaginatedStreakLeaderboard> {
     const rawLeaderboard = await this.leaderboardService.getTopStreaks(limit, offset);
     if (rawLeaderboard.length === 0) {
@@ -67,7 +67,7 @@ export class LeaderboardResolver {
     nullable: true, description: "Get current user's streak and rank."
   })
   @UseGuards(JwtAuthGuard)
-  async myStreakRank(@User() currentUser: UserType): Promise<StreakLeaderboardEntry | null> {
+  async myStreakRank(@CurrentUser() currentUser: UserType): Promise<StreakLeaderboardEntry | null> {
     const streakData = await this.leaderboardService.getUserStreakWithRank(currentUser.id);
     if (!streakData) {
       return null;

--- a/src/routes/payment/payment.module.ts
+++ b/src/routes/payment/payment.module.ts
@@ -7,12 +7,14 @@ import { EventEmitterModule } from "@nestjs/event-emitter";
 import { EventService } from "src/shared/services/event.service";
 import { SubscriptionModule } from "../subscription/subscription.module";
 import { MembershipModule } from "../membership-package/membership.module";
+import { GuardModule } from "src/shared/guards/guard.module";
 
 @Module({
     imports: [
         EventEmitterModule.forRoot(),
         SubscriptionModule,
-        MembershipModule
+        MembershipModule,
+        GuardModule
     ],
     providers: [PaymentService, PaymentRepo, PrismaService, PaymentResolver, EventService],
     exports: [PaymentService],

--- a/src/routes/payment/payment.repo.ts
+++ b/src/routes/payment/payment.repo.ts
@@ -13,8 +13,8 @@ import { MembershipService } from "../membership-package/membership.service";
 export class PaymentRepo {
     constructor(private readonly prisma: PrismaService, private readonly subscriptionService: SubscriptionService, private readonly membershipService: MembershipService) { }
 
-    async createPayment(input: CreatePaymentInput) {
-        const { user_id, membership_package_id } = input;
+    async createPayment(input: CreatePaymentInput, user_id: string) {
+        const { membership_package_id } = input;
 
         const membershipPackage = await this.membershipService.findById(membership_package_id);
 
@@ -57,7 +57,7 @@ export class PaymentRepo {
                 user_id,
                 subscription_id: subscription.id,
                 status: PaymentStatus.PENDING,
-                content: envConfig.PREFIX_PAYMENT_CODE + "_" +paymentId,
+                content: envConfig.PREFIX_PAYMENT_CODE + "_" + paymentId,
                 price: membershipPackage.price
             },
         });
@@ -65,8 +65,12 @@ export class PaymentRepo {
         return payment;
     }
 
-    async getPayments() {
-        return this.prisma.payment.findMany();
+    async getPayments(user_id: string) {
+        return this.prisma.payment.findMany({
+            where: {
+                user_id
+            }
+        });
     }
 
     async getPaymentById(id: string) {

--- a/src/routes/payment/payment.resolver.ts
+++ b/src/routes/payment/payment.resolver.ts
@@ -3,14 +3,21 @@ import { PaymentService } from "./payment.service";
 import { PaymentEntity } from "./entities/payment.entity";
 import { CreatePaymentInput } from "./dto/request/create-payment";
 import { UpdatePaymentInput } from "./dto/request/update-payment";
+import { UseGuards } from "@nestjs/common";
+import { PaidSubscriptionGuard } from "src/shared/guards/paid-subscription.guard";
+import { CurrentUser } from "src/shared/decorators/current-user.decorator";
+import { UserType } from "../user/schema/user.schema";
+import { JwtAuthGuard } from "src/shared/guards/jwt-auth.guard";
+import { Roles } from "src/shared/decorators/roles.decorator";
 
 @Resolver()
+@UseGuards(JwtAuthGuard)
 export class PaymentResolver {
     constructor(private readonly paymentService: PaymentService) { }
 
     @Query(() => [PaymentEntity])
-    async getPayments() {
-        return this.paymentService.getPayments();
+    async getPayments(@CurrentUser() user: UserType) {
+        return this.paymentService.getPayments(user.id);
     }
 
     @Query(() => PaymentEntity)
@@ -18,12 +25,15 @@ export class PaymentResolver {
         return this.paymentService.getPaymentById(id);
     }
 
+    @UseGuards(PaidSubscriptionGuard)
     @Mutation(() => PaymentEntity)
-    async createPayment(@Args('input') input: CreatePaymentInput) {
-        return this.paymentService.createPayment(input);
+    async createPayment(@Args('input') input: CreatePaymentInput,
+        @CurrentUser() user: UserType) {
+        return this.paymentService.createPayment(input, user.id);
     }
 
     @Mutation(() => PaymentEntity)
+    @Roles("ADMIN")
     async updatePayment(@Args('input') input: UpdatePaymentInput) {
         return this.paymentService.updatePayment(input);
     }

--- a/src/routes/payment/payment.service.ts
+++ b/src/routes/payment/payment.service.ts
@@ -13,17 +13,15 @@ export class PaymentService {
     ) {
     }
 
-    async createPayment(input: CreatePaymentInput): Promise<PaymentType> {
+    async createPayment(input: CreatePaymentInput, user_id: string): Promise<PaymentType> {
         // Create initial payment record
-        const payment = await this.paymentRepo.createPayment({
-            ...input,
-        });
+        const payment = await this.paymentRepo.createPayment(input, user_id);
 
         return payment;
     }
 
-    async getPayments() {
-        return this.paymentRepo.getPayments();
+    async getPayments(user_id: string) {
+        return this.paymentRepo.getPayments(user_id);
     }
 
     async getPaymentById(id: string) {

--- a/src/routes/plan-stage-template/plan-stage-template.resolver.ts
+++ b/src/routes/plan-stage-template/plan-stage-template.resolver.ts
@@ -8,7 +8,7 @@ import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
 import { RolesGuard } from '../../shared/guards/roles.guard'
 import { RoleName } from '../../shared/constants/role.constant'
 import { Roles } from '../../shared/decorators/roles.decorator'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema'
 import { CreatePlanStageTemplateInput } from './dto/requests/create-plan-stage-template.input'
 import { UpdatePlanStageTemplateInput } from './dto/requests/update-plan-stage-template.input'
@@ -39,7 +39,7 @@ export class PlanStageTemplateResolver {
   @Mutation(() => PlanStageTemplate)
   async createPlanStageTemplate(
       @Args('input') input: CreatePlanStageTemplateInput,
-      @User() user: UserType,
+      @CurrentUser() user: UserType,
   ) {
     return this.planStageTemplateService.create(input, user.role);
   }
@@ -49,7 +49,7 @@ export class PlanStageTemplateResolver {
   @Mutation(() => PlanStageTemplate)
   async updatePlanStageTemplate(
       @Args('input') input: UpdatePlanStageTemplateInput,
-      @User() user: UserType,
+      @CurrentUser() user: UserType,
   ) {
     const { id, ...updateData } = input;
     return this.planStageTemplateService.update(id, updateData, user.role);
@@ -58,7 +58,7 @@ export class PlanStageTemplateResolver {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleName.Coach)
   @Mutation(() => PlanStageTemplate)
-  async removePlanStageTemplate(@Args('id') id: string, @User() user: UserType) {
+  async removePlanStageTemplate(@Args('id') id: string, @CurrentUser() user: UserType) {
     return this.planStageTemplateService.remove(id, user.role);
   }
 
@@ -68,7 +68,7 @@ export class PlanStageTemplateResolver {
   async reorderPlanStageTemplates(
       @Args('templateId') templateId: string,
       @Args('stageOrders', { type: () => [StageOrderInput] }) stageOrders: StageOrderInput[],
-      @User() user: UserType,
+      @CurrentUser() user: UserType,
   ) {
     return this.planStageTemplateService.reorderStages(
         templateId,

--- a/src/routes/plan-stage/plan-stage.resolver.ts
+++ b/src/routes/plan-stage/plan-stage.resolver.ts
@@ -9,7 +9,7 @@ import { PlanStageStatisticsResponse } from './dto/response/plan-stage-statistic
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard';
 import { RolesGuard } from '../../shared/guards/roles.guard';
 import { Roles } from '../../shared/decorators/roles.decorator';
-import { User } from '../../shared/decorators/current-user.decorator';
+import { CurrentUser } from '../../shared/decorators/current-user.decorator';
 import { RoleName } from '../../shared/constants/role.constant';
 import { UserType } from '../user/schema/user.schema';
 import { PlanStageOrderInput } from './dto/request/plan-stage-order.input'
@@ -22,7 +22,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async planStagesByPlan(
     @Args('planId') planId: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage[]> {
     return this.planStageService.findByPlanId(planId, user.role, user.id);
   }
@@ -31,7 +31,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async planStage(
     @Args('id') id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage> {
     return this.planStageService.findOne(id, user.role, user.id);
   }
@@ -40,7 +40,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async activePlanStagesByPlan(
     @Args('planId') planId: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage[]> {
     return this.planStageService.findActiveByPlanId(planId, user.role, user.id);
   }
@@ -50,7 +50,7 @@ export class PlanStageResolver {
   @Roles(RoleName.Coach, RoleName.Admin)
   async planStageStatistics(
     @Args('filters', { nullable: true }) filters?: PlanStageFiltersInput,
-    @User() user?: UserType,
+    @CurrentUser() user?: UserType,
   ): Promise<PlanStageStatisticsResponse> {
     return this.planStageService.getStageStatistics(filters, user?.role, user?.id);
   }
@@ -59,7 +59,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async createPlanStage(
     @Args('input') input: CreatePlanStageInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage> {
     return this.planStageService.create(input, user.role, user.id);
   }
@@ -68,7 +68,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async updatePlanStage(
     @Args('input') input: UpdatePlanStageInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage> {
     const { id, ...updateData } = input;
     return this.planStageService.update(id, updateData, user.role, user.id);
@@ -78,7 +78,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async createStagesFromTemplate(
     @Args('planId') planId: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage[]> {
     return this.planStageService.createStagesFromTemplate(planId, user.role, user.id);
   }
@@ -88,7 +88,7 @@ export class PlanStageResolver {
   async reorderPlanStages(
     @Args('planId') planId: string,
     @Args('stageOrders', { type: () => [PlanStageOrderInput] }) stageOrders: PlanStageOrderInput[],
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage[]> {
     return this.planStageService.reorderStages(
       planId,
@@ -102,7 +102,7 @@ export class PlanStageResolver {
   @UseGuards(JwtAuthGuard)
   async removePlanStage(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PlanStage> {
     return this.planStageService.remove(id, user.role, user.id);
   }

--- a/src/routes/post-comment/post-comment.resolver.ts
+++ b/src/routes/post-comment/post-comment.resolver.ts
@@ -5,7 +5,7 @@ import { CreatePostCommentInput } from './dto/request/create-post-comment.input'
 import { UpdatePostCommentInput } from './dto/request/update-post-comment.input';
 import { UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema'
 import { PaginatedPostCommentsResponse } from './dto/response/paginated-post-comment.response'
 import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
@@ -20,7 +20,7 @@ export class PostCommentResolver {
   @Mutation(() => PostComment, { description: 'Create a new comment on a shared post.' })
   async createPostComment(
     @Args('input') input: CreatePostCommentInput,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<PostComment> {
     return this.postCommentService.createComment(input, currentUser);
   }
@@ -55,7 +55,7 @@ export class PostCommentResolver {
   async updatePostComment(
     @Args('commentId', { type: () => ID }) commentId: string,
     @Args('input') input: UpdatePostCommentInput,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<PostComment> {
     return this.postCommentService.updateComment(commentId, input, currentUser);
   }
@@ -63,7 +63,7 @@ export class PostCommentResolver {
   @Mutation(() => PostComment, { description: 'Delete a comment.' })
   async deletePostComment(
     @Args('commentId', { type: () => ID }) commentId: string,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<PostComment> {
     return this.postCommentService.deleteComment(commentId, currentUser);
   }

--- a/src/routes/post-like/post-like.resolver.ts
+++ b/src/routes/post-like/post-like.resolver.ts
@@ -4,7 +4,7 @@ import { PostLike } from './entities/post-like.entity'
 import { UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
 import { ManagePostLikeInput } from './dto/request/manage-post-like.input'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema'
 import { PaginatedPostLikesResponse } from './dto/response/paginated-post-like.response'
 import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
@@ -17,7 +17,7 @@ export class PostLikeResolver {
   @Mutation(() => PostLike, { description: 'Like a shared post.' })
   async likeSharedPost(
     @Args('input') input: ManagePostLikeInput,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<PostLike> {
     return this.postLikeService.likePost(input.shared_post_id, currentUser);
   }
@@ -25,7 +25,7 @@ export class PostLikeResolver {
   @Mutation(() => PostLike, { description: 'Unlike a shared post.' })
   async unlikeSharedPost(
     @Args('input') input: ManagePostLikeInput,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<PostLike> {
     return this.postLikeService.unlikePost(input.shared_post_id, currentUser);
   }
@@ -41,7 +41,7 @@ export class PostLikeResolver {
 
   @Query(() => PaginatedPostLikesResponse, { name: 'myLikedPosts', description: 'Get posts liked by the current user.' })
   async getMyLikedPosts(
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
     @Args('params', { type: () => PaginationParamsInput, nullable: true, defaultValue: { page: 1, limit: 10, orderBy: 'created_at', sortOrder: 'desc' } })
     params: PaginationParamsInput,
   ): Promise<PaginatedPostLikesResponse> {

--- a/src/routes/progress-record/progress-record.resolver.ts
+++ b/src/routes/progress-record/progress-record.resolver.ts
@@ -5,7 +5,7 @@ import { CreateProgressRecordInput } from './dto/request/create-progress-record.
 import { UpdateProgressRecordInput } from './dto/request/update-progress-record.input'
 import { UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
-import {User} from "../../shared/decorators/current-user.decorator";
+import {CurrentUser} from "../../shared/decorators/current-user.decorator";
 import {UserType} from "../user/schema/user.schema";
 import { PaginatedProgressRecordsResponse } from './dto/response/paginated-progress-records.response'
 import { PaginationParamsInput } from 'src/shared/models/dto/request/pagination-params.input'
@@ -23,7 +23,7 @@ export class ProgressRecordResolver {
   @Mutation(() => ProgressRecord)
   async createProgressRecord(
     @Args('input') input: CreateProgressRecordInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<ProgressRecord> {
     return this.progressRecordService.create(input, user);
   }
@@ -34,7 +34,7 @@ export class ProgressRecordResolver {
     params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => ProgressRecordFiltersInput })
     filters: ProgressRecordFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ) {
     return this.progressRecordService.findAll(params, filters, user);
   }
@@ -43,7 +43,7 @@ export class ProgressRecordResolver {
   @Query(() => ProgressRecord, { nullable: true })
   async progressRecord(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<ProgressRecord | null> {
     return this.progressRecordService.findOne(id, user);
   }
@@ -52,7 +52,7 @@ export class ProgressRecordResolver {
   @Mutation(() => ProgressRecord)
   async updateProgressRecord(
     @Args('input') input: UpdateProgressRecordInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<ProgressRecord> {
     const { id, ...data } = input;
     return this.progressRecordService.update(id, data, user);
@@ -62,7 +62,7 @@ export class ProgressRecordResolver {
   @Mutation(() => ProgressRecord)
   async removeProgressRecord(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<ProgressRecord> {
     return this.progressRecordService.remove(id, user);
   }

--- a/src/routes/shared-post/shared-post.resolver.ts
+++ b/src/routes/shared-post/shared-post.resolver.ts
@@ -5,7 +5,7 @@ import { CreateSharedPostInput } from './dto/request/create-shared-post.input';
 import { UpdateSharedPostInput } from './dto/request/update-shared-post.input'
 import { UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema'
 import { PaginatedSharedPostsResponse } from './dto/response/paginated-shared-post.response'
 import { PaginationParamsInput } from '../../shared/models/dto/request/pagination-params.input'
@@ -19,7 +19,7 @@ export class SharedPostResolver {
   @Mutation(() => SharedPost, { description: 'Create a new shared post from a UserBadge' })
   async createSharedPost(
     @Args('input') input: CreateSharedPostInput,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<SharedPost> {
     return this.sharedPostService.create(input, currentUser);
   }
@@ -44,7 +44,7 @@ export class SharedPostResolver {
   async updateSharedPost(
     @Args('id', { type: () => ID }) id: string,
     @Args('input') input: UpdateSharedPostInput,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<SharedPost> {
     return this.sharedPostService.update(id, input, currentUser);
   }
@@ -53,7 +53,7 @@ export class SharedPostResolver {
   @Mutation(() => SharedPost, { description: 'Delete a shared post' })
   async removeSharedPost(
     @Args('id', { type: () => ID }) id: string,
-    @User() currentUser: UserType,
+    @CurrentUser() currentUser: UserType,
   ): Promise<SharedPost> {
     return this.sharedPostService.remove(id, currentUser);
   }

--- a/src/routes/subscription/subscription.repo.ts
+++ b/src/routes/subscription/subscription.repo.ts
@@ -28,9 +28,12 @@ export class SubscriptionRepo {
     }
 
     async getUserSubscription(user_id: string) {
-        const subscription = await this.prisma.userSubscription.findFirst({
+        const subscription = await this.prisma.userSubscription.findMany({
             where: { user_id }
         })
+        if (subscription.length === 0) {
+            throw new NotFoundException('Subscription not found')
+        }
         return subscription
     }
 

--- a/src/routes/subscription/subscription.resolver.ts
+++ b/src/routes/subscription/subscription.resolver.ts
@@ -8,23 +8,25 @@ import { UseGuards } from "@nestjs/common";
 import { Roles } from "src/shared/decorators/roles.decorator";
 import { RoleName } from "src/shared/constants/role.constant";
 import { UpdateSubscriptionInput } from "./dto/request/update-subscription.input";
+import { CurrentUser } from "src/shared/decorators/current-user.decorator";
+import { UserType } from "../user/schema/user.schema";
 
 @Resolver(() => UserSubscription)
 @UseGuards(JwtAuthGuard)
 export class SubscriptionResolver {
     constructor(private readonly subscriptionService: SubscriptionService) { }
 
-    @Query(() => UserSubscription)
-    async getUserSubscription(@Args('user_id') user_id: string) {
-        return this.subscriptionService.getUserSubscription(user_id);
+    @Query(() => [UserSubscription])
+    async getUserSubscription(@CurrentUser() user: UserType) {
+        return this.subscriptionService.getUserSubscription(user.id);
     }
 
-    @UseGuards(RolesGuard)
-    @Roles(RoleName.Admin)
-    @Mutation(() => UserSubscription)
-    async createSubscription(@Args('input') input: CreateSubscriptionInput) {
-        return this.subscriptionService.createSubscription(input);
-    }
+    // @UseGuards(RolesGuard)
+    // @Roles(RoleName.Admin)
+    // @Mutation(() => UserSubscription)
+    // async createSubscription(@Args('input') input: CreateSubscriptionInput) {
+    //     return this.subscriptionService.createSubscription(input);
+    // }
 
     @UseGuards(RolesGuard)
     @Roles(RoleName.Admin)

--- a/src/routes/subscription/subscription.service.ts
+++ b/src/routes/subscription/subscription.service.ts
@@ -22,8 +22,8 @@ export class SubscriptionService {
     }
 
     async getUserSubscription(user_id: string) {
-        const subscription = await this.subscriptionRepo.getUserSubscription(user_id)
-        return subscription
+        const subscriptions = await this.subscriptionRepo.getUserSubscription(user_id)
+        return subscriptions || [];
     }
 }
 

--- a/src/routes/user-badge/user-badge.resolver.ts
+++ b/src/routes/user-badge/user-badge.resolver.ts
@@ -7,7 +7,7 @@ import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard'
 import { PaginatedUserBadgesResponse } from './dto/response/paginated-user-badge.response'
 import { PaginationParamsInput } from 'src/shared/models/dto/request/pagination-params.input';
 import { UserBadgeFiltersInput } from './dto/request/user-badge-filter.input'
-import { User } from '../../shared/decorators/current-user.decorator'
+import { CurrentUser } from '../../shared/decorators/current-user.decorator'
 import { UserType } from '../user/schema/user.schema'
 import { RolesGuard } from '../../shared/guards/roles.guard'
 import { Roles } from '../../shared/decorators/roles.decorator'
@@ -27,7 +27,7 @@ export class UserBadgeResolver {
     params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => UserBadgeFiltersInput })
     filters: UserBadgeFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PaginatedUserBadgesResponse> {
     return this.userBadgeService.getMyBadges(params, filters, user);
   }
@@ -43,7 +43,7 @@ export class UserBadgeResolver {
     params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => UserBadgeFiltersInput })
     filters: UserBadgeFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PaginatedUserBadgesResponse> {
     return this.userBadgeService.getUserBadges(userId, params, filters, user);
   }
@@ -60,7 +60,7 @@ export class UserBadgeResolver {
     params: PaginationParamsInput,
     @Args('filters', { nullable: true, type: () => UserBadgeFiltersInput })
     filters: UserBadgeFiltersInput,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<PaginatedUserBadgesResponse> {
     return this.userBadgeService.getAllUserBadges(params, filters, user);
   }
@@ -68,7 +68,7 @@ export class UserBadgeResolver {
   @Query(() => UserBadge, { nullable: true })
   async userBadge(
     @Args('id', { type: () => ID }) id: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<UserBadge | null> {
     try {
       return await this.userBadgeService.findOne(id, user);
@@ -78,7 +78,7 @@ export class UserBadgeResolver {
   }
 
   @Query(() => String, { description: 'Get my badge statistics' })
-  async myBadgeStats(@User() user: UserType): Promise<string> {
+  async myBadgeStats(@CurrentUser() user: UserType): Promise<string> {
     const stats = await this.userBadgeService.getMyBadgeStats(user);
     return JSON.stringify(stats);
   }
@@ -86,7 +86,7 @@ export class UserBadgeResolver {
   @Query(() => String, { description: 'Get badge statistics for a specific user' })
   async userBadgeStats(
     @Args('userId', { type: () => ID }) userId: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<string> {
     const stats = await this.userBadgeService.getUserBadgeStats(userId, user);
     return JSON.stringify(stats);
@@ -98,7 +98,7 @@ export class UserBadgeResolver {
   async awardBadge(
     @Args('userId', { type: () => ID }) userId: string,
     @Args('badgeId', { type: () => ID }) badgeId: string,
-    @User() user: UserType,
+    @CurrentUser() user: UserType,
   ): Promise<UserBadge> {
     return this.userBadgeService.awardBadge(userId, badgeId, user);
   }

--- a/src/routes/user/user.resolver.ts
+++ b/src/routes/user/user.resolver.ts
@@ -11,6 +11,8 @@ import { RolesGuard } from 'src/shared/guards/roles.guard'
 import { UpdateUserProfileInput } from './dto/update-user-profile.input'
 import { SignupBodySchema, SignupBodyType } from '../auth/schema/signup.schema'
 import { AuthResponse } from '../auth/dto/response/auth.response'
+import { CurrentUser } from 'src/shared/decorators/current-user.decorator'
+import { UserType } from './schema/user.schema'
 
 @Resolver(() => User)
 export class UserResolver {
@@ -20,15 +22,16 @@ export class UserResolver {
   @Mutation(() => User)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('MEMBER', 'COACH')
-  async updateUserProfile(@Args('updateUserInput') updateUserInput: UpdateUserProfileInput) {
-    return await this.userService.updateProfile(updateUserInput.id, updateUserInput)
+  async updateUserProfile(@Args('updateUserInput') updateUserInput: UpdateUserProfileInput,
+    @CurrentUser() user: UserType) {
+    return await this.userService.updateProfile(user.id, updateUserInput)
   }
 
   @Query(() => User, { name: 'findOneUser' })
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN', 'MEMBER', 'COACH')
-  async findOneUser(@Args('id', { type: () => String }) id: string) {
-    return await this.userService.findOne(id)
+  @Roles('MEMBER', 'COACH')
+  async findOneUser(@CurrentUser() user: UserType) {
+    return await this.userService.findOne(user.id)
   }
 
   //Admin

--- a/src/shared/decorators/current-user.decorator.ts
+++ b/src/shared/decorators/current-user.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common'
 import { GqlExecutionContext } from '@nestjs/graphql'
 
-export const User = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+export const CurrentUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const gqlContext = GqlExecutionContext.create(ctx).getContext()
   const user = gqlContext.req.user
 

--- a/src/shared/guards/paid-subscription.guard.ts
+++ b/src/shared/guards/paid-subscription.guard.ts
@@ -1,0 +1,31 @@
+import { CanActivate, ExecutionContext, Injectable, ForbiddenException } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { PrismaService } from '../services/prisma.service';
+import { SubscriptionStatus } from '../constants/subscription.constant';
+
+@Injectable()
+export class PaidSubscriptionGuard implements CanActivate {
+    constructor(private readonly prisma: PrismaService) { }
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const ctx = GqlExecutionContext.create(context);
+        const { user } = ctx.getContext().req;
+
+        if (!user) {
+            throw new ForbiddenException('User not authenticated');
+        }
+        // Check if user has any active subscriptions
+        const activeSubscriptions = await this.prisma.userSubscription.findMany({   
+            where: {
+                user_id: user.user_id,
+                status: SubscriptionStatus.Active
+            }
+        });
+
+        if (activeSubscriptions.length > 0) {
+            throw new ForbiddenException('You already have an active subscription. Cannot create new payment.');
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This pull request refactors the usage of the `@User` decorator across multiple resolver files to use the `@CurrentUser` decorator instead. This change improves code clarity and ensures consistency in identifying the current user in GraphQL resolvers.

### Refactoring to `@CurrentUser` decorator:

#### Badge-related resolvers:
* Updated all methods in `BadgeTypeResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/badge-type/badge-type.resolver.ts`) [[1]](diffhunk://#diff-9e7e8f59c8b4afe450f7b9bedbd738de3d34d1c09bb8559fd5b21367ff34b268L27-R27) [[2]](diffhunk://#diff-9e7e8f59c8b4afe450f7b9bedbd738de3d34d1c09bb8559fd5b21367ff34b268L51-R59) [[3]](diffhunk://#diff-9e7e8f59c8b4afe450f7b9bedbd738de3d34d1c09bb8559fd5b21367ff34b268L70-R70) [[4]](diffhunk://#diff-9e7e8f59c8b4afe450f7b9bedbd738de3d34d1c09bb8559fd5b21367ff34b268L80-R80)
* Updated all methods in `BadgeResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/badge/badge.resolver.ts`) [[1]](diffhunk://#diff-baafd0d2eb7233de23b1e0607f01fbd44c0f3f258e8b5a2666d3099565a07d68L27-R27) [[2]](diffhunk://#diff-baafd0d2eb7233de23b1e0607f01fbd44c0f3f258e8b5a2666d3099565a07d68L51-R59) [[3]](diffhunk://#diff-baafd0d2eb7233de23b1e0607f01fbd44c0f3f258e8b5a2666d3099565a07d68L70-R70) [[4]](diffhunk://#diff-baafd0d2eb7233de23b1e0607f01fbd44c0f3f258e8b5a2666d3099565a07d68L80-R80)

#### Blog-related resolvers:
* Updated all methods in `BlogResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/blog/blog.resolver.ts`) [[1]](diffhunk://#diff-fd19e37498e24fd988f3ba2ddca9f0b2cf9dd126b616b4f9e944023b4dcd9ee6L29-R29) [[2]](diffhunk://#diff-fd19e37498e24fd988f3ba2ddca9f0b2cf9dd126b616b4f9e944023b4dcd9ee6L65-R65) [[3]](diffhunk://#diff-fd19e37498e24fd988f3ba2ddca9f0b2cf9dd126b616b4f9e944023b4dcd9ee6L74-R74)

#### Cessation plan-related resolvers:
* Updated all methods in `CessationPlanTemplateResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/cessation-plan-template/cessation-plan-template.resolver.ts`) [[1]](diffhunk://#diff-938bde0a903a9ba75e174c213dae48cda50b7e9d74e43760effbb8a5a364a82dL25-R25) [[2]](diffhunk://#diff-938bde0a903a9ba75e174c213dae48cda50b7e9d74e43760effbb8a5a364a82dL61-R61)
* Updated all methods in `CessationPlanResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/cessation-plan/cessation-plan.resolver.ts`) [[1]](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL28-R28) [[2]](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL38-R38) [[3]](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL52-R60) [[4]](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL69-R69) [[5]](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL79-R79)

#### Chat-related resolvers:
* Updated all methods in `ChatResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/chat/chat.resolver.ts`) [[1]](diffhunk://#diff-e54f176b55aab198e9e2cb8feea8aa2cf51ec4f87c286252aeb8f8ca00f79aedL22-R46) [[2]](diffhunk://#diff-e54f176b55aab198e9e2cb8feea8aa2cf51ec4f87c286252aeb8f8ca00f79aedL69-R70)

#### Feedback-related resolvers:
* Updated all methods in `FeedbackResolver` to replace `@User()` with `@CurrentUser()`. (`src/routes/feedback/feedback.resolver.ts`) [[1]](diffhunk://#diff-7187afc7d27b4107568a589ea5f85b31ebd3c5c2e2aa5c213019781851792e59L22-R22) [[2]](diffhunk://#diff-7187afc7d27b4107568a589ea5f85b31ebd3c5c2e2aa5c213019781851792e59L41-R41) [[3]](diffhunk://#diff-7187afc7d27b4107568a589ea5f85b31ebd3c5c2e2aa5c213019781851792e59L50-R58)