### PR TITLE
prisma(health-score-criteria): add HealthScoreCriteria model

### DIFF
--- a/prisma/migrations/20250711083350_add_health_score_criteria/migration.sql
+++ b/prisma/migrations/20250711083350_add_health_score_criteria/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "health_score_criteria" (
+    "id" TEXT NOT NULL,
+    "coach_id" TEXT NOT NULL,
+    "title" VARCHAR(200) NOT NULL,
+    "description" TEXT NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "health_score_criteria_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "health_score_criteria_coach_id_idx" ON "health_score_criteria"("coach_id");
+
+-- CreateIndex
+CREATE INDEX "health_score_criteria_is_active_idx" ON "health_score_criteria"("is_active");
+
+-- CreateIndex
+CREATE INDEX "health_score_criteria_created_at_idx" ON "health_score_criteria"("created_at");
+
+-- AddForeignKey
+ALTER TABLE "health_score_criteria" ADD CONSTRAINT "health_score_criteria_coach_id_fkey" FOREIGN KEY ("coach_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   ChatRoomCreator        ChatRoom[]              @relation("ChatRoomCreator")
   ChatRoomReceiver       ChatRoom[]              @relation("ChatRoomReceiver")
   ChatMessage            ChatMessage[]
+  HealthScoreCriteria    HealthScoreCriteria[]
 
   @@map("user")
 }
@@ -388,6 +389,23 @@ model ChatMessage {
   updated_at   DateTime @updatedAt
 
   @@map("chat_message")
+}
+
+model HealthScoreCriteria {
+  id          String   @id @default(uuid())
+  coach_id    String
+  title       String   @db.VarChar(200)
+  description String
+  is_active   Boolean  @default(true)
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  coach User @relation(fields: [coach_id], references: [id], onDelete: Cascade)
+
+  @@index([coach_id])
+  @@index([is_active])
+  @@index([created_at])
+  @@map("health_score_criteria")
 }
 
 enum PaymentStatus {


### PR DESCRIPTION
This pull request introduces a new `HealthScoreCriteria` model to the database schema, along with associated migrations and updates to the `User` model. The changes aim to support the creation and management of health score criteria linked to coaches.

### Database schema changes:

* Added a new table `health_score_criteria` with fields such as `id`, `coach_id`, `title`, `description`, `is_active`, `created_at`, and `updated_at`. It includes a primary key, multiple indexes, and a foreign key constraint linking `coach_id` to the `user` table. (`prisma/migrations/20250711083350_add_health_score_criteria/migration.sql`)

* Introduced a new `HealthScoreCriteria` model in the Prisma schema with corresponding fields and relations. The model includes indexes for `coach_id`, `is_active`, and `created_at`. (`prisma/schema.prisma`)

### Model updates:

* Updated the `User` model to include a one-to-many relationship with the `HealthScoreCriteria` model, allowing users to act as coaches for associated health score criteria. (`prisma/schema.prisma`)