### PR TITLE
refactor(plan): include coach_id in plan details selection

### DIFF
--- a/src/routes/cessation-plan/cessation-plan.repository.ts
+++ b/src/routes/cessation-plan/cessation-plan.repository.ts
@@ -252,6 +252,7 @@ export class CessationPlanRepository {
           name: true,
           difficulty_level: true,
           estimated_duration_days: true,
+          coach_id: true,
         },
       },
       stages: {


### PR DESCRIPTION
This pull request adds a new field to the `CessationPlanRepository` to include the `coach_id` in the selected data.

* [`src/routes/cessation-plan/cessation-plan.repository.ts`](diffhunk://#diff-6d81bf6184053c47fd87aa5aa27214578213174ea0a721b8357b4110310236d4R255): Added the `coach_id` field to the `CessationPlanRepository` to ensure the coach's identifier is included in the selected data for cessation plans.