### PR TITLE
Fix/create cessation plan

### DIFF
--- a/src/routes/cessation-plan-template/cessation-plan-template.repository.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.repository.ts
@@ -65,12 +65,50 @@ export class CessationPlanTemplateRepository {
       ]
     }
 
+    let orderByClause: Prisma.CessationPlanTemplateOrderByWithRelationInput[]
+
+    if (orderBy === 'average_rating') {
+      orderByClause = [
+        { average_rating: 'desc' },
+        { success_rate: 'desc' },
+        { created_at: 'desc' },
+      ]
+    } else if (orderBy === 'success_rate') {
+      orderByClause = [
+        { success_rate: 'desc' },
+        { average_rating: 'desc' },
+        { created_at: 'desc' },
+      ]
+    } else if (orderBy === 'total_reviews') {
+      orderByClause = [
+        { total_reviews: 'desc' },
+        { average_rating: 'desc' },
+        { success_rate: 'desc' },
+        { created_at: 'desc' },
+      ]
+    } else {
+      if (!orderBy || orderBy === 'created_at') {
+        orderByClause = [
+          { average_rating: 'desc' },
+          { success_rate: 'desc' },
+          { created_at: sortOrder || 'desc' },
+        ]
+      } else {
+        orderByClause = [
+          { [orderBy]: sortOrder },
+          { average_rating: 'desc' },
+          { success_rate: 'desc' },
+          { created_at: 'desc' },
+        ]
+      }
+    }
+
     const [data, total] = await Promise.all([
       this.prisma.cessationPlanTemplate.findMany({
         where,
         skip,
         take: limit,
-        orderBy: { [orderBy]: sortOrder },
+        orderBy: orderByClause,
         include: {
           stages: {
             where: {is_active: true},

--- a/src/routes/cessation-plan-template/cessation-plan-template.service.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.service.ts
@@ -69,7 +69,6 @@ export class CessationPlanTemplateService {
             reviveDates(template, ['created_at', 'updated_at'])
           })
         }
-        this.logger.debug(`Cache hit for templates: ${cacheKey}`)
         return parsed
       }
     } catch (error) {
@@ -198,8 +197,6 @@ export class CessationPlanTemplateService {
             reviveDates(plan, ['start_date', 'target_date', 'created_at', 'updated_at'])
           })
         }
-
-        this.logger.debug(`Cache hit for template usage stats: ${templateId}`)
         return this.transformToUsageStatsResponse(parsed)
       }
     } catch (error) {
@@ -214,7 +211,6 @@ export class CessationPlanTemplateService {
 
     try {
       await this.redisServices.getClient().setEx(cacheKey, CACHE_TTL, JSON.stringify(result))
-      this.logger.debug(`Cache set for template usage stats: ${templateId}`)
     } catch (error) {
       this.logger.warn(`Cache set failed for template usage stats ${templateId}: ${error.message}`)
     }
@@ -246,7 +242,6 @@ export class CessationPlanTemplateService {
       if (templateId) {
         const specificTemplateKey = buildOneCacheKey(CACHE_PREFIX, templateId)
         await client.del(specificTemplateKey)
-        this.logger.debug(`Cleared specific template cache: ${specificTemplateKey}`)
       }
 
       // Step 2: Clear all template list caches
@@ -260,7 +255,6 @@ export class CessationPlanTemplateService {
           const keys = await client.keys(pattern)
           if (keys.length > 0) {
             await client.del(keys)
-            this.logger.debug(`Cleared ${keys.length} template cache keys with pattern: ${pattern}`)
           }
         } catch (error) {
           this.logger.warn(`Failed to clear template cache pattern ${pattern}: ${error.message}`)

--- a/src/routes/cessation-plan/cessation-plan.repository.ts
+++ b/src/routes/cessation-plan/cessation-plan.repository.ts
@@ -95,24 +95,29 @@ export class CessationPlanRepository {
     });
   }
 
-  async findByUserId(userId: string) {
-    return this.prisma.cessationPlan.findMany({
-      where: { user_id: userId, is_deleted: false },
-      include: this.getDefaultIncludes(),
-      orderBy: { created_at: 'desc' },
-    });
-  }
-
   async findActiveByUserId(userId: string) {
     return this.prisma.cessationPlan.findMany({
       where: {
         user_id: userId,
+        status: {
+          in: ['PLANNING', 'ACTIVE', 'PAUSED'],
+        },
         is_deleted: false,
-        status: { in: ['PLANNING', 'ACTIVE', 'PAUSED'] },
       },
       include: this.getDefaultIncludes(),
       orderBy: { created_at: 'desc' },
-    });
+    })
+  }
+
+  async findByUserId(userId: string) {
+    return this.prisma.cessationPlan.findMany({
+      where: {
+        user_id: userId,
+        is_deleted: false,
+      },
+      include: this.getDefaultIncludes(),
+      orderBy: { created_at: 'desc' },
+    })
   }
 
   async findByUserAndTemplate(userId: string, templateId: string) {

--- a/src/routes/cessation-plan/cessation-plan.resolver.ts
+++ b/src/routes/cessation-plan/cessation-plan.resolver.ts
@@ -1,6 +1,5 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { SubscriptionGuard } from '../../shared/guards/subscription.guard';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { CessationPlanService } from './cessation-plan.service';
 import { CreateCessationPlanInput } from './dto/request/create-cessation-plan.input';
 import { UpdateCessationPlanInput } from './dto/request/update-cessation-plan.input';

--- a/src/routes/cessation-plan/cessation-plan.service.ts
+++ b/src/routes/cessation-plan/cessation-plan.service.ts
@@ -371,8 +371,8 @@ export class CessationPlanService {
   private validateStatusTransition(currentStatus: CessationPlanStatus, newStatus: CessationPlanStatus): void {
     const validTransitions: Record<CessationPlanStatus, CessationPlanStatus[]> = {
       PLANNING: ['ACTIVE', 'CANCELLED'],
-      ACTIVE: ['PAUSED', 'COMPLETED', 'CANCELLED'],
-      PAUSED: ['ACTIVE', 'CANCELLED'],
+      ACTIVE: ['PAUSED', 'COMPLETED', 'CANCELLED', 'ABANDONED'],
+      PAUSED: ['ACTIVE', 'CANCELLED', 'ABANDONED'],
       COMPLETED: [],
       ABANDONED: ['CANCELLED'],
       CANCELLED: ['PLANNING'],
@@ -384,9 +384,15 @@ export class CessationPlanService {
   }
 
   private async validateCreateRules(data: CreateCessationPlanType, userId: string): Promise<void> {
-    const existingActivePlans = await this.cessationPlanRepository.findActiveByUserId(userId)
-    if (existingActivePlans.length > 0) {
-      throw new ConflictException('User already has an active cessation plan')
+    const activeStatuses = ['PLANNING', 'ACTIVE', 'PAUSED']
+    const existingActivePlans = await this.cessationPlanRepository.findByUserId(userId)
+
+    const activePlans = existingActivePlans.filter(plan =>
+      activeStatuses.includes(plan.status)
+    )
+
+    if (activePlans.length > 0) {
+      throw new ConflictException('You already have an active cessation plan. Please complete or cancel it before creating a new one.')
     }
 
     if (data.target_date <= data.start_date) {
@@ -446,11 +452,9 @@ export class CessationPlanService {
   }
 
   private async invalidateTemplateCaches(templateId: string): Promise<void> {
-    // Invalidate specific template cache
     const templateCacheKey = buildOneCacheKey('cessation-plan-template', templateId);
     await this.redisServices.getClient().del(templateCacheKey);
 
-    // Invalidate template lists cache
     await invalidateCacheForId(this.redisServices.getClient(), 'cessation-plan-template', 'all-lists');
     await invalidateCacheForId(this.redisServices.getClient(), 'cessation-plan-template', 'items');
   }

--- a/src/routes/plan-stage/plan-stage.resolver.ts
+++ b/src/routes/plan-stage/plan-stage.resolver.ts
@@ -18,6 +18,24 @@ import { PlanStageOrderInput } from './dto/request/plan-stage-order.input'
 export class PlanStageResolver {
   constructor(private readonly planStageService: PlanStageService) {}
 
+  @Mutation(() => PlanStage)
+  @UseGuards(JwtAuthGuard)
+  async createPlanStage(
+    @Args('input') input: CreatePlanStageInput,
+    @CurrentUser() user: UserType,
+  ): Promise<PlanStage> {
+    return this.planStageService.create(input, user.role, user.id);
+  }
+
+  @Mutation(() => [PlanStage])
+  @UseGuards(JwtAuthGuard)
+  async createStagesFromTemplate(
+    @Args('planId') planId: string,
+    @CurrentUser() user: UserType,
+  ): Promise<PlanStage[]> {
+    return this.planStageService.createStagesFromTemplate(planId, user.role, user.id);
+  }
+
   @Query(() => [PlanStage])
   @UseGuards(JwtAuthGuard)
   async planStagesByPlan(
@@ -57,30 +75,12 @@ export class PlanStageResolver {
 
   @Mutation(() => PlanStage)
   @UseGuards(JwtAuthGuard)
-  async createPlanStage(
-    @Args('input') input: CreatePlanStageInput,
-    @CurrentUser() user: UserType,
-  ): Promise<PlanStage> {
-    return this.planStageService.create(input, user.role, user.id);
-  }
-
-  @Mutation(() => PlanStage)
-  @UseGuards(JwtAuthGuard)
   async updatePlanStage(
     @Args('input') input: UpdatePlanStageInput,
     @CurrentUser() user: UserType,
   ): Promise<PlanStage> {
     const { id, ...updateData } = input;
     return this.planStageService.update(id, updateData, user.role, user.id);
-  }
-
-  @Mutation(() => [PlanStage])
-  @UseGuards(JwtAuthGuard)
-  async createStagesFromTemplate(
-    @Args('planId') planId: string,
-    @CurrentUser() user: UserType,
-  ): Promise<PlanStage[]> {
-    return this.planStageService.createStagesFromTemplate(planId, user.role, user.id);
   }
 
   @Mutation(() => [PlanStage])


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple services and repositories, focusing on improving sorting logic, cache handling, and plan stage management. The most significant changes include adding more flexible sorting options, refining cache management by removing unnecessary debug logs, and enforcing stricter validation for plan stage operations based on plan status.

### Enhancements to Sorting Logic:
* Introduced a dynamic `orderByClause` in `CessationPlanTemplateRepository` to allow sorting by `average_rating`, `success_rate`, `total_reviews`, or `created_at` with fallback logic. (`src/routes/cessation-plan-template/cessation-plan-template.repository.ts`, [src/routes/cessation-plan-template/cessation-plan-template.repository.tsR68-R111](diffhunk://#diff-9a386c771b3e7f115e0ca6c5428e97d3f8bb85d68337c263667da2a8ababfde2R68-R111))

### Cache Management Improvements:
* Removed redundant debug logs related to cache hits, cache sets, and cache clearing operations in `CessationPlanTemplateService`. (`src/routes/cessation-plan-template/cessation-plan-template.service.ts`, [[1]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL72) [[2]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL201-L202) [[3]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL217) [[4]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL249) [[5]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL263)
* Simplified cache invalidation logic by removing unnecessary comments and redundant operations in `PlanStageService`. (`src/routes/plan-stage/plan-stage.service.ts`, [[1]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L283-L289) [[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77L329)

### Plan Stage Management Enhancements:
* Added validations to restrict stage creation, updates, reordering, and deletion based on plan status. Operations are now limited to plans in `PLANNING`, `ACTIVE`, or `PAUSED` status. (`src/routes/plan-stage/plan-stage.service.ts`, [[1]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R47-R51) [[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R210-R221) [[3]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R254-R258) [[4]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R284-R287) [[5]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R477-R486)
* Introduced a new helper method `validatePlanAllowsStageModification` to centralize status validation logic. (`src/routes/plan-stage/plan-stage.service.ts`, [src/routes/plan-stage/plan-stage.service.tsR477-R486](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R477-R486))

### Repository and Service Refinements:
* Renamed and updated the logic of methods in `CessationPlanRepository` to clarify their purpose and ensure proper filtering of active plans. (`src/routes/cessation-plan/cessation-plan.repository.ts`, [src/routes/cessation-plan/cessation-plan.repository.tsL98-R120](diffhunk://#diff-6d81bf6184053c47fd87aa5aa27214578213174ea0a721b8357b4110310236d4L98-R120))
* Enhanced the `validateCreateRules` method in `CessationPlanService` to filter active plans more robustly before allowing new plan creation. (`src/routes/cessation-plan/cessation-plan.service.ts`, [src/routes/cessation-plan/cessation-plan.service.tsL387-R395](diffhunk://#diff-8479545bf990931ba6c68d1cb059ac750166ff0052d4dd0efccaae2531d1762cL387-R395))

### GraphQL Resolver Updates:
* Removed unused `SubscriptionGuard` import from `CessationPlanResolver`. (`src/routes/cessation-plan/cessation-plan.resolver.ts`, [src/routes/cessation-plan/cessation-plan.resolver.tsL2-R2](diffhunk://#diff-ead88fb3e7e479a4e78bb984884f8463b64e5cdd74d166fb9ce78130d6b92d3bL2-R2))
* Reorganized mutations in `PlanStageResolver` to streamline the resolver structure. (`src/routes/plan-stage/plan-stage.resolver.ts`, [[1]](diffhunk://#diff-d1e3d8c7d9432fcabf174dd67bb804c3809c68c1bb56c7a8e4b44263b1814df5R21-R38) [[2]](diffhunk://#diff-d1e3d8c7d9432fcabf174dd67bb804c3809c68c1bb56c7a8e4b44263b1814df5L58-L66) [[3]](diffhunk://#diff-d1e3d8c7d9432fcabf174dd67bb804c3809c68c1bb56c7a8e4b44263b1814df5L77-L85)