### PR TITLE
Enhance/cessation plan template

### DIFF
--- a/src/routes/cessation-plan-template/cessation-plan-template.repository.ts
+++ b/src/routes/cessation-plan-template/cessation-plan-template.repository.ts
@@ -89,9 +89,9 @@ export class CessationPlanTemplateRepository {
     } else {
       if (!orderBy || orderBy === 'created_at') {
         orderByClause = [
+          { created_at: sortOrder || 'desc' },
           { average_rating: 'desc' },
           { success_rate: 'desc' },
-          { created_at: sortOrder || 'desc' },
         ]
       } else {
         orderByClause = [
@@ -119,6 +119,7 @@ export class CessationPlanTemplateRepository {
               duration_days: true,
               description: true,
               recommended_actions: true,
+              max_cigarettes_per_day: true
             },
             orderBy: { stage_order: 'asc' },
           },
@@ -161,6 +162,7 @@ export class CessationPlanTemplateRepository {
             duration_days: true,
             description: true,
             recommended_actions: true,
+            max_cigarettes_per_day: true
           },
           orderBy: { stage_order: 'asc' },
         },

--- a/src/routes/cessation-plan/cessation-plan.service.ts
+++ b/src/routes/cessation-plan/cessation-plan.service.ts
@@ -131,17 +131,6 @@ export class CessationPlanService {
     return planStartDate <= today
   }
 
-  private isStartDateToday(startDate: Date): boolean {
-    const now = new Date()
-    const today = new Date(now)
-    today.setHours(0, 0, 0, 0)
-
-    const planStartDate = new Date(startDate)
-    planStartDate.setHours(0, 0, 0, 0)
-
-    return planStartDate.getTime() === today.getTime()
-  }
-
   private async activateFirstStage(planId: string): Promise<void> {
     try {
       const firstStage = await this.planStageRepository.findByStageOrder(planId, 1)
@@ -178,10 +167,10 @@ export class CessationPlanService {
       throw new BadRequestException('Target date must be after start date')
     }
 
-    await this.validateStartDate(data.start_date)
+    this.validateStartDate(data.start_date)
   }
 
-  private async validateStartDate(startDate: Date): Promise<void> {
+  private validateStartDate(startDate: Date): void {
     const now = new Date()
     const today = new Date(now)
     today.setHours(0, 0, 0, 0)

--- a/src/routes/plan-stage-template/dto/requests/create-plan-stage-template.input.ts
+++ b/src/routes/plan-stage-template/dto/requests/create-plan-stage-template.input.ts
@@ -21,4 +21,10 @@ export class CreatePlanStageTemplateInput extends createZodDto(CreatePlanStageTe
 
   @Field(() => String, { nullable: true })
   recommended_actions?: string;
+
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Maximum number of cigarettes allowed per day in this stage'
+  })
+  max_cigarettes_per_day?: number;
 }

--- a/src/routes/plan-stage-template/dto/requests/update-plan-stage-template.input.ts
+++ b/src/routes/plan-stage-template/dto/requests/update-plan-stage-template.input.ts
@@ -24,4 +24,10 @@ export class UpdatePlanStageTemplateInput extends createZodDto(UpdatePlanStageTe
 
   @Field(() => String, { nullable: true })
   recommended_actions?: string;
+
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Maximum number of cigarettes allowed per day in this stage'
+  })
+  max_cigarettes_per_day?: number;
 }

--- a/src/routes/plan-stage-template/entities/plan-stage-template.entity.ts
+++ b/src/routes/plan-stage-template/entities/plan-stage-template.entity.ts
@@ -24,6 +24,12 @@ export class PlanStageTemplate implements PlanStageTemplateType {
   @Field(() => String, { nullable: true })
   recommended_actions?: string
 
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Maximum number of cigarettes allowed per day in this stage'
+  })
+  max_cigarettes_per_day?: number
+
   @Field(() => Boolean)
   is_active: boolean
 

--- a/src/routes/plan-stage-template/plan-stage-template.repository.ts
+++ b/src/routes/plan-stage-template/plan-stage-template.repository.ts
@@ -9,6 +9,30 @@ import { UpdatePlanStageTemplateType } from './schema/update-plan-stage-template
 export class PlanStageTemplateRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async create(data: CreatePlanStageTemplateType) {
+    const createData: Prisma.PlanStageTemplateCreateInput = {
+      title: data.title,
+      description: data.description,
+      stage_order: data.stage_order,
+      duration_days: data.duration_days,
+      recommended_actions: data.recommended_actions,
+      max_cigarettes_per_day: data.max_cigarettes_per_day,
+      is_active: true,
+      template: {
+        connect: { id: data.template_id },
+      },
+    };
+
+    return this.prisma.planStageTemplate.create({
+      data: createData,
+      include: {
+        template: {
+          select: { id: true, name: true, difficulty_level: true },
+        },
+      },
+    });
+  }
+
   async findAll(params: PaginationParamsType, templateId: string) {
     const { page, limit, search, orderBy, sortOrder } = params;
     const skip = (page - 1) * limit;
@@ -92,29 +116,6 @@ export class PlanStageTemplateRepository {
     });
   }
 
-  async create(data: CreatePlanStageTemplateType) {
-    const createData: Prisma.PlanStageTemplateCreateInput = {
-      title: data.title,
-      description: data.description,
-      stage_order: data.stage_order,
-      duration_days: data.duration_days,
-      recommended_actions: data.recommended_actions,
-      is_active: true,
-      template: {
-        connect: { id: data.template_id },
-      },
-    };
-
-    return this.prisma.planStageTemplate.create({
-      data: createData,
-      include: {
-        template: {
-          select: { id: true, name: true, difficulty_level: true },
-        },
-      },
-    });
-  }
-
   async update(id: string, data: Omit<UpdatePlanStageTemplateType, 'id'>) {
     const updateData: Prisma.PlanStageTemplateUpdateInput = {};
 
@@ -123,6 +124,7 @@ export class PlanStageTemplateRepository {
     if (data.stage_order !== undefined) updateData.stage_order = data.stage_order;
     if (data.duration_days !== undefined) updateData.duration_days = data.duration_days;
     if (data.recommended_actions !== undefined) updateData.recommended_actions = data.recommended_actions;
+    if (data.max_cigarettes_per_day !== undefined) updateData.max_cigarettes_per_day = data.max_cigarettes_per_day;
 
     if (data.template_id !== undefined) {
       updateData.template = {

--- a/src/routes/plan-stage-template/schema/create-plan-stage-template.schema.ts
+++ b/src/routes/plan-stage-template/schema/create-plan-stage-template.schema.ts
@@ -21,6 +21,11 @@ export const CreatePlanStageTemplateSchema = z.object({
   recommended_actions: z.string()
       .max(2000, 'Recommended actions must be less than 2000 characters')
       .optional(),
+  max_cigarettes_per_day: z.number()
+    .int('Max cigarettes must be an integer')
+    .min(0, 'Max cigarettes cannot be negative')
+    .max(100, 'Max cigarettes per day cannot exceed 100')
+    .optional(),
 });
 
 export type CreatePlanStageTemplateType = z.infer<typeof CreatePlanStageTemplateSchema>;

--- a/src/routes/plan-stage/dto/request/create-plan-stage.input.ts
+++ b/src/routes/plan-stage/dto/request/create-plan-stage.input.ts
@@ -27,4 +27,10 @@ export class CreatePlanStageInput extends createZodDto(CreatePlanStageSchema) {
 
   @Field(() => String, { nullable: true })
   actions?: string;
+
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Maximum number of cigarettes allowed per day in this stage'
+  })
+  max_cigarettes_per_day?: number;
 }

--- a/src/routes/plan-stage/dto/request/update-plan-stage.input.ts
+++ b/src/routes/plan-stage/dto/request/update-plan-stage.input.ts
@@ -32,6 +32,12 @@ export class UpdatePlanStageInput extends createZodDto(UpdatePlanStageSchema) {
   @Field(() => String, { nullable: true })
   actions?: string;
 
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Maximum number of cigarettes allowed per day in this stage'
+  })
+  max_cigarettes_per_day?: number;
+
   @Field(() => PlanStageStatus, { nullable: true })
   status?: PlanStageStatus;
 

--- a/src/routes/plan-stage/entities/plan-stage.entity.ts
+++ b/src/routes/plan-stage/entities/plan-stage.entity.ts
@@ -32,6 +32,12 @@ export class PlanStage implements PlanStageType {
   @Field(() => String, { nullable: true })
   actions?: string;
 
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Maximum number of cigarettes allowed per day in this stage'
+  })
+  max_cigarettes_per_day?: number
+
   @Field(() => PlanStageStatus)
   status: PlanStageStatus;
 

--- a/src/routes/plan-stage/plan-stage.repository.ts
+++ b/src/routes/plan-stage/plan-stage.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { PlanStageStatus, Prisma } from '@prisma/client'
 import { PrismaService } from '../../shared/services/prisma.service';
 import { PaginationParamsType } from '../../shared/models/pagination.model';
 import { CreatePlanStageType } from './schema/create-plan-stage.schema';
@@ -19,7 +19,7 @@ export interface PlanStageFilters {
 export class PlanStageRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(data: CreatePlanStageType) {
+  async create(data: CreatePlanStageType & { status?: PlanStageStatus }) {
     return this.prisma.planStage.create({
       data: {
         plan_id: data.plan_id,
@@ -30,7 +30,8 @@ export class PlanStageRepository {
         end_date: data.end_date,
         description: data.description,
         actions: data.actions,
-        status: 'PENDING',
+        max_cigarettes_per_day: data.max_cigarettes_per_day,
+        status: data.status || PlanStageStatus.PENDING,
         is_deleted: false,
       },
       include: this.getDefaultIncludes(),
@@ -50,14 +51,32 @@ export class PlanStageRepository {
       return { count: 0 };
     }
 
+    const plan = await this.prisma.cessationPlan.findUnique({
+      where: { id: planId },
+      select: { status: true },
+    });
+
     const createStagesData = [];
     let currentDate = new Date(planStartDate);
+    const now = new Date();
+    const today = new Date(now);
+    today.setHours(0, 0, 0, 0);
 
     for (const templateStage of templateStages) {
       const stageStartDate = new Date(currentDate);
-
       const stageEndDate = new Date(stageStartDate);
       stageEndDate.setDate(stageEndDate.getDate() + templateStage.duration_days - 1);
+
+      let stageStatus: PlanStageStatus = PlanStageStatus.PENDING;
+
+      if (plan?.status === 'ACTIVE') {
+        const stageStartDateOnly = new Date(stageStartDate);
+        stageStartDateOnly.setHours(0, 0, 0, 0);
+
+        if (templateStage.stage_order === 1 && stageStartDateOnly.getTime() <= today.getTime()) {
+          stageStatus = PlanStageStatus.ACTIVE;
+        }
+      }
 
       createStagesData.push({
         plan_id: planId,
@@ -66,7 +85,8 @@ export class PlanStageRepository {
         title: templateStage.title,
         description: templateStage.description,
         actions: templateStage.recommended_actions,
-        status: 'PENDING' as const,
+        max_cigarettes_per_day: templateStage.max_cigarettes_per_day,
+        status: stageStatus,
         start_date: stageStartDate,
         end_date: stageEndDate,
       });

--- a/src/routes/plan-stage/schema/create-plan-stage.schema.ts
+++ b/src/routes/plan-stage/schema/create-plan-stage.schema.ts
@@ -21,6 +21,12 @@ export const CreatePlanStageSchema = z.object({
   actions: z.string()
     .max(2000, 'Actions must be less than 2000 characters')
     .optional(),
+  max_cigarettes_per_day: z.number()
+    .int('Max cigarettes must be an integer')
+    .min(0, 'Max cigarettes cannot be negative')
+    .max(100, 'Max cigarettes per day cannot exceed 100')
+    .optional(),
+  status: z.string().optional(),
 }).refine(data => {
   if (data.start_date && data.end_date) {
     return data.end_date > data.start_date;

--- a/src/routes/plan-stage/schema/update-plan-stage.schema.ts
+++ b/src/routes/plan-stage/schema/update-plan-stage.schema.ts
@@ -26,6 +26,11 @@ export const UpdatePlanStageSchema = z.object({
   actions: z.string()
     .max(2000, 'Actions must be less than 2000 characters')
     .optional(),
+  max_cigarettes_per_day: z.number()
+    .int('Max cigarettes must be an integer')
+    .min(0, 'Max cigarettes cannot be negative')
+    .max(100, 'Max cigarettes per day cannot exceed 100')
+    .optional(),
   status: z.nativeEnum(PlanStageStatus).optional(),
   completion_notes: z.string()
     .max(1000, 'Completion notes must be less than 1000 characters')


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings across the cessation plan and plan stage modules. The key changes include adding support for a new `max_cigarettes_per_day` field in templates and stages, improving the initialization logic for plan stage statuses, and cleaning up redundant code and comments. Below is a categorized summary of the most significant changes:

### Feature Enhancements
* Added a new `max_cigarettes_per_day` field to `PlanStageTemplate` and `PlanStage` entities, DTOs, and schemas, allowing for better control over smoking cessation plans. (`[[1]](diffhunk://#diff-30bb16170bfdfebccd32f1b9f3458bfe76ebaae02f93c3c3ce25c4004dfb6afaR24-R29)`, `[[2]](diffhunk://#diff-7b997c64e21dd4a2f2f2661e7035355686a8ce65dc1f9bed46991ad1cdfc103aR27-R32)`, `[[3]](diffhunk://#diff-0dcb1539ee20c4761851c53fd20be911c20b3118fd89e8f15a45b12d5e14f239R27-R32)`, `[[4]](diffhunk://#diff-39584ab616f8f2c087aa7bcc7626471277a685ef2938e993ece6b2d683db6e68R30-R35)`, `[[5]](diffhunk://#diff-d10b8bd4517af7fa347ecc3b8fe4f238456997d5a6ab9ecdb2bd7c0cc07b2d0eR35-R40)`, `[[6]](diffhunk://#diff-bda101f2d404ad37082b94194e132ae6f61cbd8264103fd72eb8a6f6cf474d24R35-R40)`, `[[7]](diffhunk://#diff-04bb97fbcd5cb689255004504b066e58aa16a7113caffd24b3ef9e52a9c15216R127)`, `[[8]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6L33-R34)`)
* Updated repository methods to handle the new `max_cigarettes_per_day` field during creation and updates. (`[[1]](diffhunk://#diff-04bb97fbcd5cb689255004504b066e58aa16a7113caffd24b3ef9e52a9c15216R12-R35)`, `[[2]](diffhunk://#diff-04bb97fbcd5cb689255004504b066e58aa16a7113caffd24b3ef9e52a9c15216R127)`, `[[3]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6L33-R34)`)

### Plan Stage Status Improvements
* Enhanced the logic for determining the initial status of plan stages (`PENDING` or `ACTIVE`) based on the plan's status and start date. This ensures more accurate state initialization. (`[[1]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R54-R89)`, `[[2]](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R56-R93)`)
* Introduced a helper method `determineInitialStageStatus` in `PlanStageService` to encapsulate the logic for setting the initial stage status. (`[src/routes/plan-stage/plan-stage.service.tsR56-R93](diffhunk://#diff-628808b73c336a080e9232615395ed74f259071fa89eeaee86ce485a734bef77R56-R93)`)

### Code Cleanup and Refactoring
* Removed redundant comments and logging statements across the `CessationPlanTemplateService` to streamline the codebase. (`[[1]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL52-L58)`, `[[2]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL89)`, `[[3]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL121)`, `[[4]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL144-L145)`, `[[5]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL156-L159)`, `[[6]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL171-L172)`, `[[7]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL347-L354)`, `[[8]](diffhunk://#diff-553a70e9870cd390f4cea0df9aca1ac877751eb0b85cf66f0d9380825f4305fbL401-L402)`)
* Simplified the `validateStartDate` method in `CessationPlanService` by making it synchronous and removing an unused private method. (`[[1]](diffhunk://#diff-8479545bf990931ba6c68d1cb059ac750166ff0052d4dd0efccaae2531d1762cL134-L144)`, `[[2]](diffhunk://#diff-8479545bf990931ba6c68d1cb059ac750166ff0052d4dd0efccaae2531d1762cL181-R173)`)

### Bug Fix
* Fixed the order of the `created_at` field in the `orderByClause` array in `CessationPlanTemplateRepository` to ensure consistent sorting behavior. (`[src/routes/cessation-plan-template/cessation-plan-template.repository.tsR92-L94](diffhunk://#diff-9a386c771b3e7f115e0ca6c5428e97d3f8bb85d68337c263667da2a8ababfde2R92-L94)`)

### Other Changes
* Added logic to handle the `status` field during plan stage creation, allowing for better flexibility in setting custom statuses. (`[[1]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6L22-R22)`, `[[2]](diffhunk://#diff-776b9281aad5563100e1b8ae57e8a77616de5c972467c99e41d1f129c99574f6R54-R89)`)